### PR TITLE
Adding teamID to all the api's

### DIFF
--- a/components/tables/GoalieScoreTable.tsx
+++ b/components/tables/GoalieScoreTable.tsx
@@ -76,6 +76,24 @@ export const GoalieScoreTable = ({
             columnHelper.accessor('team', {
               enableGlobalFilter: true,
               header: () => <TableHeader title="Team">Team</TableHeader>,
+              cell: (props) => {
+                const cellValue = props.getValue();
+                return (
+                  <Link
+                    href={{
+                      pathname: '/[league]/team/[id]',
+                      query: {
+                        league: router.query.league,
+                        id: props.row.original.teamID,
+                        season: props.row.original.season,
+                      },
+                    }}
+                    className="inline-block w-full max-w-[100px] truncate text-center leading-none text-blue600"
+                  >
+                    {cellValue}
+                  </Link>
+                );
+              },
             }),
           ]
         : []),

--- a/components/tables/SkaterScoreTable.tsx
+++ b/components/tables/SkaterScoreTable.tsx
@@ -89,6 +89,24 @@ export const SkaterScoreTable = ({
                 columnHelper.accessor('team', {
                   enableGlobalFilter: false,
                   header: () => <TableHeader title="Team">Team</TableHeader>,
+                  cell: (props) => {
+                    const cellValue = props.getValue();
+                    return (
+                      <Link
+                        href={{
+                          pathname: '/[league]/team/[id]',
+                          query: {
+                            league: router.query.league,
+                            id: props.row.original.teamID,
+                            season: props.row.original.season,
+                          },
+                        }}
+                        className="inline-block w-full max-w-[100px] truncate text-center leading-none text-blue600"
+                      >
+                        {cellValue}
+                      </Link>
+                    );
+                  },
                 }),
               ]
             : []),

--- a/pages/[league]/player/[id].tsx
+++ b/pages/[league]/player/[id].tsx
@@ -230,11 +230,13 @@ export default ({ playerId, league }: { playerId: string; league: League }) => {
             </div>
             {shouldShowIndexView && (
               <div className="my-2.5 flex flex-col items-center justify-center space-y-5">
-                <TeamLogo
-                  league={league}
-                  teamAbbreviation={playerInfo[0]?.team}
-                  className="mt-10 size-40 md:mt-2.5"
-                />
+                <Link href={`/${league}/team/${playerInfo[0].teamID}`}>
+                  <TeamLogo
+                    league={league}
+                    teamAbbreviation={playerInfo[0]?.team}
+                    className="mt-10 size-40 md:mt-2.5"
+                  />
+                </Link>
                 <div className=" group flex items-center gap-2 text-3xl font-bold uppercase">
                   {playerNameInfo?.name ?? 'Player'}
                 </div>

--- a/pages/api/v1/goalies/[id].ts
+++ b/pages/api/v1/goalies/[id].ts
@@ -13,6 +13,7 @@ const cors = Cors({
 interface MasterPlayer {
   PlayerID: number;
   Abbr: string;
+  TeamID: number;
   FranchiseID: number;
   LeagueID: number;
   SeasonID: number;
@@ -62,6 +63,7 @@ const getPlayerInfo = (player: MasterPlayer) => ({
   season: player.SeasonID,
   name: player['Last Name'],
   team: player.Abbr,
+  teamID: player.TeamID,
   position: player.position,
   height: player.Height,
   weight: player.Weight,

--- a/pages/api/v1/goalies/stats/[id].ts
+++ b/pages/api/v1/goalies/stats/[id].ts
@@ -92,6 +92,7 @@ export default async (
       shutouts: player.Shutouts,
       savePct: player.SavePct.toFixed(3),
       gameRating: player.GameRating,
+      teamID: player.TeamID,
     };
   });
 

--- a/pages/api/v1/players/[id].ts
+++ b/pages/api/v1/players/[id].ts
@@ -88,6 +88,7 @@ export default async (
       season: player.SeasonID,
       name: player['Last Name'],
       team: player.Abbr,
+      teamID: player.TeamID,
       position: player.position,
       height: player.Height,
       weight: player.Weight,

--- a/pages/api/v1/players/stats/[id].ts
+++ b/pages/api/v1/players/stats/[id].ts
@@ -129,6 +129,7 @@ export default async (
         FFPct: player.FFPct,
         FFPctRel: player.FFPctRel,
       },
+      teamID: player.TeamID,
     };
   });
 

--- a/typings/api.d.ts
+++ b/typings/api.d.ts
@@ -35,6 +35,7 @@ export type Player = {
   gameRating: number;
   offensiveGameRating: number;
   defensiveGameRating: number;
+  teamID: number;
 };
 
 export type PlayerInfo = {
@@ -44,6 +45,7 @@ export type PlayerInfo = {
   season: number;
   weight: number;
   team: string;
+  teamID: number;
   position: 'C' | 'LW' | 'RW' | 'LD' | 'RD';
 };
 
@@ -84,6 +86,7 @@ export type Goalie = {
   shutouts: number;
   savePct: number;
   gameRating: number;
+  teamID: number;
 };
 
 export type GoalieInfo = {
@@ -93,6 +96,7 @@ export type GoalieInfo = {
   season: number;
   weight: number;
   team: string;
+  teamID: number;
 };
 
 export type Team = {


### PR DESCRIPTION
Adding TeamIDs to all the api routes so that we can add hyperlinks to the team names in the player pages and the logo

- Allows users to quickly go from player pages to team pages to see a particular season