### PR TITLE
Feat/history apis

### DIFF
--- a/pages/api/v1/goalies/stats/allTime.ts
+++ b/pages/api/v1/goalies/stats/allTime.ts
@@ -46,49 +46,6 @@ export default async (
   }
 
   const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.wins;
-
-  const goalieString = SQL`
-      SELECT 
-        s.PlayerID,
-        s.LeagueID,
-        MAX(p.\`Last Name\`) AS Name,
-        COUNT(DISTINCT s.SeasonID) AS Seasons,
-        SUM(s.GP) AS GP,
-        SUM(s.Minutes) AS Minutes,
-        SUM(s.Wins) AS Wins,
-        SUM(s.Losses) AS Losses,
-        SUM(s.OT) AS OT,
-        SUM(s.ShotsAgainst) AS ShotsAgainst,
-        SUM(s.Saves) AS Saves,
-        SUM(s.GoalsAgainst) AS GoalsAgainst,
-        AVG(s.GAA) AS GAA,
-        SUM(s.Shutouts) AS Shutouts,
-        AVG(s.SavePct) AS SavePct,
-        AVG(s.GameRating) AS GameRating
-      FROM `
-    .append(`player_goalie_stats_${type} AS s`)
-    .append(
-      SQL`
-      INNER JOIN player_master AS p
-        ON s.SeasonID = p.SeasonID
-       AND s.LeagueID = p.LeagueID
-       AND s.PlayerID = p.PlayerID
-      INNER JOIN corrected_player_ratings AS r
-        ON s.SeasonID = r.SeasonID
-       AND s.LeagueID = r.LeagueID
-       AND s.PlayerID = r.PlayerID
-      WHERE s.LeagueID = ${+league}
-      `,
-    )
-    .append(startSeason != null ? SQL` AND s.SeasonID >= ${+startSeason} ` : '')
-    .append(endSeason != null ? SQL` AND s.SeasonID <= ${+endSeason} ` : '')
-    .append(SQL`
-      GROUP BY s.PlayerID, s.LeagueID
-      ORDER BY ${sortSql};
-      `);
-
-  console.log(goalieString);
-
   const goalieStats = await query(
     SQL`
       SELECT 

--- a/pages/api/v1/goalies/stats/allTime.ts
+++ b/pages/api/v1/goalies/stats/allTime.ts
@@ -34,6 +34,7 @@ export default async (
     sort,
     startSeason,
     endSeason,
+    teamID,
   } = req.query;
 
   let type: string;
@@ -83,6 +84,7 @@ export default async (
         startSeason != null ? SQL` AND s.SeasonID >= ${+startSeason} ` : '',
       )
       .append(endSeason != null ? SQL` AND s.SeasonID <= ${+endSeason} ` : '')
+      .append(teamID != null ? SQL` AND s.TeamID = ${+teamID} ` : '')
       .append(SQL`
       GROUP BY s.PlayerID, s.LeagueID`).append(`
       ORDER BY ${sortSql};

--- a/pages/api/v1/goalies/stats/allTime.ts
+++ b/pages/api/v1/goalies/stats/allTime.ts
@@ -92,7 +92,7 @@ export default async (
         ON s.SeasonID = p.SeasonID
        AND s.LeagueID = p.LeagueID
        AND s.PlayerID = p.PlayerID
-      INNER JOIN corrected_player_ratings AS r
+      INNER JOIN player_ratings AS r
         ON s.SeasonID = r.SeasonID
        AND s.LeagueID = r.LeagueID
        AND s.PlayerID = r.PlayerID

--- a/pages/api/v1/goalies/stats/allTime.ts
+++ b/pages/api/v1/goalies/stats/allTime.ts
@@ -1,0 +1,158 @@
+//@ts-nocheck
+import Cors from 'cors';
+import { NextApiRequest, NextApiResponse } from 'next';
+import SQL from 'sql-template-strings';
+
+import { query } from '../../../../../lib/db';
+import use from '../../../../../lib/middleware';
+
+const cors = Cors({
+  methods: ['GET', 'HEAD'],
+});
+
+const SORTABLE_COLUMNS: Record<string, string> = {
+  wins: 'Wins DESC',
+  losses: 'Losses DESC',
+  ot: 'OT DESC',
+  goalsAgainst: 'GoalsAgainst ASC',
+  shutouts: 'Shutouts DESC',
+  savePct: 'SavePct DESC',
+  gaa: 'GAA ASC',
+  minutes: 'Minutes DESC',
+  gamesPlayed: 'GP DESC',
+};
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  await use(req, res, cors);
+
+  const {
+    league = 0,
+    type: longType = 'regular',
+    sort,
+    startSeason,
+    endSeason,
+  } = req.query;
+
+  let type: string;
+  if (longType === 'preseason') {
+    type = 'ps';
+  } else if (longType === 'playoffs') {
+    type = 'po';
+  } else {
+    type = 'rs';
+  }
+
+  const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.wins;
+
+  const goalieString = SQL`
+      SELECT 
+        s.PlayerID,
+        s.LeagueID,
+        MAX(p.\`Last Name\`) AS Name,
+        COUNT(DISTINCT s.SeasonID) AS Seasons,
+        SUM(s.GP) AS GP,
+        SUM(s.Minutes) AS Minutes,
+        SUM(s.Wins) AS Wins,
+        SUM(s.Losses) AS Losses,
+        SUM(s.OT) AS OT,
+        SUM(s.ShotsAgainst) AS ShotsAgainst,
+        SUM(s.Saves) AS Saves,
+        SUM(s.GoalsAgainst) AS GoalsAgainst,
+        AVG(s.GAA) AS GAA,
+        SUM(s.Shutouts) AS Shutouts,
+        AVG(s.SavePct) AS SavePct,
+        AVG(s.GameRating) AS GameRating
+      FROM `
+    .append(`player_goalie_stats_${type} AS s`)
+    .append(
+      SQL`
+      INNER JOIN player_master AS p
+        ON s.SeasonID = p.SeasonID
+       AND s.LeagueID = p.LeagueID
+       AND s.PlayerID = p.PlayerID
+      INNER JOIN corrected_player_ratings AS r
+        ON s.SeasonID = r.SeasonID
+       AND s.LeagueID = r.LeagueID
+       AND s.PlayerID = r.PlayerID
+      WHERE s.LeagueID = ${+league}
+      `,
+    )
+    .append(startSeason != null ? SQL` AND s.SeasonID >= ${+startSeason} ` : '')
+    .append(endSeason != null ? SQL` AND s.SeasonID <= ${+endSeason} ` : '')
+    .append(SQL`
+      GROUP BY s.PlayerID, s.LeagueID
+      ORDER BY ${sortSql};
+      `);
+
+  console.log(goalieString);
+
+  const goalieStats = await query(
+    SQL`
+      SELECT 
+        s.PlayerID,
+        s.LeagueID,
+        MAX(p.\`Last Name\`) AS Name,
+        COUNT(DISTINCT s.SeasonID) AS Seasons,
+        SUM(s.GP) AS GP,
+        SUM(s.Minutes) AS Minutes,
+        SUM(s.Wins) AS Wins,
+        SUM(s.Losses) AS Losses,
+        SUM(s.OT) AS OT,
+        SUM(s.ShotsAgainst) AS ShotsAgainst,
+        SUM(s.Saves) AS Saves,
+        SUM(s.GoalsAgainst) AS GoalsAgainst,
+        AVG(s.GAA) AS GAA,
+        SUM(s.Shutouts) AS Shutouts,
+        AVG(s.SavePct) AS SavePct,
+      FROM `
+      .append(`player_goalie_stats_${type} AS s`)
+      .append(
+        SQL`
+      INNER JOIN player_master AS p
+        ON s.SeasonID = p.SeasonID
+       AND s.LeagueID = p.LeagueID
+       AND s.PlayerID = p.PlayerID
+      INNER JOIN corrected_player_ratings AS r
+        ON s.SeasonID = r.SeasonID
+       AND s.LeagueID = r.LeagueID
+       AND s.PlayerID = r.PlayerID
+      WHERE s.LeagueID = ${+league}
+      `,
+      )
+      .append(
+        startSeason != null ? SQL` AND s.SeasonID >= ${+startSeason} ` : '',
+      )
+      .append(endSeason != null ? SQL` AND s.SeasonID <= ${+endSeason} ` : '')
+      .append(SQL`
+      GROUP BY s.PlayerID, s.LeagueID`).append(`
+      ORDER BY ${sortSql};
+      `),
+  );
+
+  const parsed = [...goalieStats].map((player) => {
+    return {
+      id: player.PlayerID,
+      name: player.Name,
+      position: 'G',
+      league: player.LeagueID,
+      team: player.Abbr,
+      season: player.SeasonID,
+      gamesPlayed: player.GP,
+      minutes: player.Minutes,
+      wins: player.Wins,
+      losses: player.Losses,
+      ot: player.OT,
+      shotsAgainst: player.ShotsAgainst,
+      saves: player.Saves,
+      goalsAgainst: player.GoalsAgainst,
+      gaa: player.GAA.toFixed(2),
+      shutouts: player.Shutouts,
+      savePct: player.SavePct.toFixed(3),
+    };
+  });
+
+  res.status(200).json(parsed);
+};

--- a/pages/api/v1/goalies/stats/allTime.ts
+++ b/pages/api/v1/goalies/stats/allTime.ts
@@ -98,7 +98,16 @@ export default async (
       .append(minGP != null ? SQL` HAVING SUM(s.GP) >= ${+minGP} ` : '')
       .append(` ORDER BY ${sortSql} ${orderSql};`),
   );
-  console.log(goalieStats);
+
+  if ('error' in goalieStats) {
+    res.status(500).send('Server Connection Failed');
+    return;
+  }
+
+  if (goalieStats.length === 0) {
+    res.status(200).json([]);
+    return;
+  }
 
   const parsed = [...goalieStats].map((player) => {
     return {

--- a/pages/api/v1/goalies/stats/allTime.ts
+++ b/pages/api/v1/goalies/stats/allTime.ts
@@ -37,6 +37,7 @@ export default async (
     endSeason,
     teamID,
     minGP,
+    limit,
   } = req.query;
 
   let type: string;
@@ -96,7 +97,8 @@ export default async (
       .append(teamID != null ? SQL` AND s.TeamID = ${+teamID} ` : '')
       .append(SQL` GROUP BY s.PlayerID, s.LeagueID`)
       .append(minGP != null ? SQL` HAVING SUM(s.GP) >= ${+minGP} ` : '')
-      .append(` ORDER BY ${sortSql} ${orderSql};`),
+      .append(` ORDER BY ${sortSql} ${orderSql}`)
+      .append(limit != null ? SQL` LIMIT ${+limit};` : SQL`;`),
   );
 
   if ('error' in goalieStats) {

--- a/pages/api/v1/goalies/stats/allTime.ts
+++ b/pages/api/v1/goalies/stats/allTime.ts
@@ -11,15 +11,15 @@ const cors = Cors({
 });
 
 const SORTABLE_COLUMNS: Record<string, string> = {
-  wins: 'Wins DESC',
-  losses: 'Losses DESC',
-  ot: 'OT DESC',
-  goalsAgainst: 'GoalsAgainst ASC',
-  shutouts: 'Shutouts DESC',
-  savePct: 'SavePct DESC',
-  gaa: 'GAA ASC',
-  minutes: 'Minutes DESC',
-  gamesPlayed: 'GP DESC',
+  wins: 'Wins',
+  losses: 'Losses',
+  ot: 'OT',
+  goalsAgainst: 'GoalsAgainst',
+  shutouts: 'Shutouts',
+  savePct: 'SavePct',
+  gaa: 'GAA',
+  minutes: 'Minutes',
+  gamesPlayed: 'GP',
 };
 
 export default async (
@@ -32,9 +32,11 @@ export default async (
     league = 0,
     type: longType = 'regular',
     sort,
+    order = 'desc',
     startSeason,
     endSeason,
     teamID,
+    minGP,
   } = req.query;
 
   let type: string;
@@ -44,6 +46,13 @@ export default async (
     type = 'po';
   } else {
     type = 'rs';
+  }
+
+  let orderSql: string;
+  if (order === 'asc') {
+    orderSql = 'ASC';
+  } else {
+    orderSql = 'DESC';
   }
 
   const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.wins;
@@ -64,7 +73,7 @@ export default async (
         SUM(s.GoalsAgainst) AS GoalsAgainst,
         AVG(s.GAA) AS GAA,
         SUM(s.Shutouts) AS Shutouts,
-        AVG(s.SavePct) AS SavePct,
+        AVG(s.SavePct) AS SavePct
       FROM `
       .append(`player_goalie_stats_${type} AS s`)
       .append(
@@ -85,11 +94,11 @@ export default async (
       )
       .append(endSeason != null ? SQL` AND s.SeasonID <= ${+endSeason} ` : '')
       .append(teamID != null ? SQL` AND s.TeamID = ${+teamID} ` : '')
-      .append(SQL`
-      GROUP BY s.PlayerID, s.LeagueID`).append(`
-      ORDER BY ${sortSql};
-      `),
+      .append(SQL` GROUP BY s.PlayerID, s.LeagueID`)
+      .append(minGP != null ? SQL` HAVING SUM(s.GP) >= ${+minGP} ` : '')
+      .append(` ORDER BY ${sortSql} ${orderSql};`),
   );
+  console.log(goalieStats);
 
   const parsed = [...goalieStats].map((player) => {
     return {

--- a/pages/api/v1/goalies/stats/allTime.ts
+++ b/pages/api/v1/goalies/stats/allTime.ts
@@ -56,6 +56,15 @@ export default async (
     orderSql = 'DESC';
   }
 
+  if (startSeason != null && !validateSeason(startSeason as string)) {
+    res.status(400).json({ error: 'Invalid startSeason format' });
+    return;
+  }
+  if (endSeason != null && !validateSeason(endSeason as string)) {
+    res.status(400).json({ error: 'Invalid endSeason format' });
+    return;
+  }
+
   const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.wins;
   const goalieStats = await query(
     SQL`

--- a/pages/api/v1/players/stats/allTime.ts
+++ b/pages/api/v1/players/stats/allTime.ts
@@ -48,6 +48,7 @@ export default async (
     sort = 'points',
     startSeason,
     endSeason,
+    teamID,
   } = req.query;
 
   let type: string;
@@ -123,6 +124,7 @@ export default async (
           .append(
             endSeason != null ? SQL` AND s.SeasonID <= ${+endSeason} ` : '',
           )
+          .append(teamID != null ? SQL` AND s.TeamID = ${+teamID} ` : '')
           .append(
             SQL`
   GROUP BY s.PlayerID, s.LeagueID`,

--- a/pages/api/v1/players/stats/allTime.ts
+++ b/pages/api/v1/players/stats/allTime.ts
@@ -139,6 +139,16 @@ export default async (
       ),
   );
 
+  if ('error' in playerStats) {
+    res.status(500).send('Server Connection Failed');
+    return;
+  }
+
+  if (playerStats.length === 0) {
+    res.status(200).json([]);
+    return;
+  }
+
   const parsed = [...playerStats].map((player) => {
     return {
       id: player.PlayerID,

--- a/pages/api/v1/players/stats/allTime.ts
+++ b/pages/api/v1/players/stats/allTime.ts
@@ -71,6 +71,15 @@ export default async (
     orderSql = 'DESC';
   }
 
+  if (startSeason != null && !validateSeason(startSeason as string)) {
+    res.status(400).json({ error: 'Invalid startSeason format' });
+    return;
+  }
+  if (endSeason != null && !validateSeason(endSeason as string)) {
+    res.status(400).json({ error: 'Invalid endSeason format' });
+    return;
+  }
+
   const sortSql = SORTABLE_COLUMNS[sort];
   if (!sortSql) {
     res.status(400).json({ error: 'Invalid sort option. See API for options' });

--- a/pages/api/v1/players/stats/allTime.ts
+++ b/pages/api/v1/players/stats/allTime.ts
@@ -11,26 +11,26 @@ const cors = Cors({
 });
 
 const SORTABLE_COLUMNS: Record<string, string> = {
-  points: 'Points DESC',
-  goals: 'G DESC',
-  assists: 'A DESC',
-  gamesPlayed: 'GP DESC',
-  pim: 'PIM DESC',
-  hits: 'Hits DESC',
-  blocks: 'Blocks DESC',
-  fights: 'Fights DESC',
-  fightWins: 'Fights_Won DESC',
-  faceoffs: 'FO DESC',
-  faceoffWins: 'FOW DESC',
-  ppGoals: 'PPG DESC',
-  ppAssists: 'PPA DESC',
-  ppPoints: 'PPG + PPA DESC',
-  shGoals: 'SHG DESC',
-  shAssists: 'SHA DESC',
-  shPoints: 'SHG + SHA DESC',
-  timeOnIce: 'TOI DESC',
-  giveaways: 'GvA DESC',
-  takeaways: 'TkA DESC',
+  points: 'Points',
+  goals: 'G',
+  assists: 'A',
+  gamesPlayed: 'GP',
+  pim: 'PIM',
+  hits: 'Hits',
+  blocks: 'Blocks',
+  fights: 'Fights',
+  fightWins: 'Fights_Won',
+  faceoffs: 'FO',
+  faceoffWins: 'FOW',
+  ppGoals: 'PPG',
+  ppAssists: 'PPA',
+  ppPoints: 'PPP',
+  shGoals: 'SHG',
+  shAssists: 'SHA',
+  shPoints: 'SHPoints',
+  timeOnIce: 'TOI',
+  giveaways: 'GvA',
+  takeaways: 'TkA',
 };
 
 export type SeasonType = string;
@@ -45,10 +45,12 @@ export default async (
     league = 0,
     type: longType = 'regular',
     position,
-    sort = 'points',
+    sort,
+    order = 'desc',
     startSeason,
     endSeason,
     teamID,
+    minGP,
   } = req.query;
 
   let type: string;
@@ -58,6 +60,12 @@ export default async (
     type = 'po';
   } else {
     type = 'rs';
+  }
+  let orderSql: string;
+  if (order === 'asc') {
+    orderSql = 'ASC';
+  } else {
+    orderSql = 'DESC';
   }
 
   const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.points;
@@ -125,11 +133,9 @@ export default async (
             endSeason != null ? SQL` AND s.SeasonID <= ${+endSeason} ` : '',
           )
           .append(teamID != null ? SQL` AND s.TeamID = ${+teamID} ` : '')
-          .append(
-            SQL`
-  GROUP BY s.PlayerID, s.LeagueID`,
-          )
-          .append(` ORDER BY ${sortSql} `),
+          .append(SQL` GROUP BY s.PlayerID, s.LeagueID`)
+          .append(minGP != null ? SQL` HAVING SUM(s.GP) >= ${+minGP} ` : '')
+          .append(` ORDER BY ${sortSql} ${orderSql} `),
       ),
   );
 

--- a/pages/api/v1/players/stats/allTime.ts
+++ b/pages/api/v1/players/stats/allTime.ts
@@ -11,26 +11,28 @@ const cors = Cors({
 });
 
 const SORTABLE_COLUMNS: Record<string, string> = {
-  points: 'Points',
-  goals: 'G',
-  assists: 'A',
-  gamesPlayed: 'GP',
-  pim: 'PIM',
-  hits: 'Hits',
-  blocks: 'Blocks',
-  fights: 'Fights',
-  fightWins: 'Fights_Won',
-  faceoffs: 'FO',
-  faceoffWins: 'FOW',
-  ppGoals: 'PPG',
-  ppAssists: 'PPA',
-  ppPoints: 'PPP',
-  shGoals: 'SHG',
-  shAssists: 'SHA',
-  shPoints: 'SHPoints',
-  timeOnIce: 'TOI',
-  giveaways: 'GvA',
-  takeaways: 'TkA',
+  points: 'SUM(s.G) + SUM(s.A)',
+  goals: 'SUM(s.G)',
+  assists: 'SUM(s.A)',
+  gamesPlayed: 'SUM(s.GP)',
+  pim: 'SUM(s.PIM)',
+  hits: 'SUM(s.HIT)',
+  blocks: 'SUM(s.SB)',
+  fights: 'SUM(s.Fights)',
+  fightWins: 'SUM(s.Fights_Won)',
+  faceoffs: 'SUM(s.FO)',
+  faceoffWins: 'SUM(s.FOW)',
+  ppGoals: 'SUM(s.PPG)',
+  ppAssists: 'SUM(s.PPA)',
+  ppPoints: 'SUM(s.PPG + s.PPA)',
+  shGoals: 'SUM(s.SHG)',
+  shAssists: 'SUM(s.SHA)',
+  shPoints: 'SUM(s.SHG + s.SHA)',
+  timeOnIce: 'SUM(s.TOI)',
+  giveaways: 'SUM(s.GvA)',
+  takeaways: 'SUM(s.TkA)',
+  plusMinus: 'SUM(s.PlusMinus)',
+  shots: 'SUM(s.SOG)',
 };
 
 export type SeasonType = string;
@@ -51,6 +53,7 @@ export default async (
     endSeason,
     teamID,
     minGP,
+    limit,
   } = req.query;
 
   let type: string;
@@ -68,7 +71,11 @@ export default async (
     orderSql = 'DESC';
   }
 
-  const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.points;
+  const sortSql = SORTABLE_COLUMNS[sort];
+  if (!sortSql) {
+    res.status(400).json({ error: 'Invalid sort option. See API for options' });
+    return;
+  }
   const playerStats = await query(
     SQL`
   SELECT 
@@ -88,6 +95,7 @@ export default async (
       SUM(s.SB) AS Blocks,
       SUM(s.Fights) AS Fights,
       SUM(s.Fights_Won) AS Fights_Won,
+      SUM(s.PlusMinus) AS PlusMinus,
       SUM(s.PIM) AS PIM,
       SUM(s.PPG) AS PPG,
       SUM(s.PPA) AS PPA,
@@ -135,7 +143,8 @@ export default async (
           .append(teamID != null ? SQL` AND s.TeamID = ${+teamID} ` : '')
           .append(SQL` GROUP BY s.PlayerID, s.LeagueID`)
           .append(minGP != null ? SQL` HAVING SUM(s.GP) >= ${+minGP} ` : '')
-          .append(` ORDER BY ${sortSql} ${orderSql} `),
+          .append(` ORDER BY ${sortSql} ${orderSql} `)
+          .append(limit != null ? SQL` LIMIT ${+limit} ` : ''),
       ),
   );
 

--- a/pages/api/v1/players/stats/allTime.ts
+++ b/pages/api/v1/players/stats/allTime.ts
@@ -1,0 +1,167 @@
+//@ts-nocheck
+import Cors from 'cors';
+import { NextApiRequest, NextApiResponse } from 'next';
+import SQL from 'sql-template-strings';
+
+import { query } from '../../../../../lib/db';
+import use from '../../../../../lib/middleware';
+
+const cors = Cors({
+  methods: ['GET', 'HEAD'],
+});
+
+const SORTABLE_COLUMNS: Record<string, string> = {
+  points: 'Points DESC',
+  goals: 'G DESC',
+  assists: 'A DESC',
+  gamesPlayed: 'GP DESC',
+  pim: 'PIM DESC',
+  hits: 'Hits DESC',
+  blocks: 'Blocks DESC',
+  fights: 'Fights DESC',
+  fightWins: 'Fights_Won DESC',
+  faceoffs: 'FO DESC',
+  faceoffWins: 'FOW DESC',
+  ppGoals: 'PPG DESC',
+  ppAssists: 'PPA DESC',
+  ppPoints: 'PPG + PPA DESC',
+  shGoals: 'SHG DESC',
+  shAssists: 'SHA DESC',
+  shPoints: 'SHG + SHA DESC',
+  timeOnIce: 'TOI DESC',
+  giveaways: 'GvA DESC',
+  takeaways: 'TkA DESC',
+};
+
+export type SeasonType = string;
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  await use(req, res, cors);
+
+  const {
+    league = 0,
+    type: longType = 'regular',
+    position,
+    sort = 'points',
+    startSeason,
+    endSeason,
+  } = req.query;
+
+  let type: string;
+  if (longType === 'preseason') {
+    type = 'ps';
+  } else if (longType === 'playoffs') {
+    type = 'po';
+  } else {
+    type = 'rs';
+  }
+
+  const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.points;
+  const playerStats = await query(
+    SQL`
+  SELECT 
+      s.PlayerID,
+      s.LeagueID,
+      MAX(p.\`Last Name\`) AS Name,
+      COUNT(DISTINCT s.SeasonID) AS Seasons,
+      SUM(s.GP) AS GP,
+      SUM(s.G) AS G,
+      SUM(s.A) AS A,
+      SUM(s.G) + SUM(s.A) AS Points,
+      SUM(s.GWG) AS GWG,
+      SUM(s.TOI) AS TOI,
+      SUM(s.GvA) AS GvA,
+      SUM(s.TkA) AS TkA,
+      SUM(s.HIT) AS Hits,
+      SUM(s.SB) AS Blocks,
+      SUM(s.Fights) AS Fights,
+      SUM(s.Fights_Won) AS Fights_Won,
+      SUM(s.PIM) AS PIM,
+      SUM(s.PPG) AS PPG,
+      SUM(s.PPA) AS PPA,
+      SUM(s.PPG + s.PPA) AS PPP,
+      SUM(s.SHG) AS SHG,
+      SUM(s.SHA) AS SHA,
+      SUM(s.SHG + s.SHA) AS SHPoints,
+      SUM(s.SOG) AS SOG,
+      SUM(s.FO) AS FO,
+      SUM(s.FOW) AS FOW,
+      MAX(r.LD) AS LD,
+      MAX(r.RD) AS RD,
+      MAX(r.LW) AS LW,
+      MAX(r.C)  AS C,
+      MAX(r.RW) AS RW
+  FROM `
+      .append(`player_skater_stats_${type} AS s`)
+      .append(
+        SQL`
+  INNER JOIN player_master AS p
+    ON s.SeasonID = p.SeasonID 
+   AND s.LeagueID = p.LeagueID
+   AND s.PlayerID = p.PlayerID
+  INNER JOIN corrected_player_ratings AS r
+    ON s.SeasonID = r.SeasonID 
+   AND s.LeagueID = r.LeagueID
+   AND s.PlayerID = r.PlayerID
+  WHERE s.LeagueID = ${+league}
+    AND r.G < 19
+    AND p.TeamID >= 0
+  `
+          .append(
+            position === 'forward'
+              ? SQL` AND (r.LD < 20 AND r.RD < 20) `
+              : position === 'defenseman'
+              ? SQL` AND (r.LD = 20 OR r.RD = 20) `
+              : SQL``,
+          )
+          .append(
+            startSeason != null ? SQL` AND s.SeasonID >= ${+startSeason} ` : '',
+          )
+          .append(
+            endSeason != null ? SQL` AND s.SeasonID <= ${+endSeason} ` : '',
+          )
+          .append(
+            SQL`
+  GROUP BY s.PlayerID, s.LeagueID`,
+          )
+          .append(` ORDER BY ${sortSql} `),
+      ),
+  );
+
+  const parsed = [...playerStats].map((player) => {
+    return {
+      id: player.PlayerID,
+      name: player.Name,
+      league: player.LeagueID,
+      seasons: player.Seasons,
+      gamesPlayed: player.GP,
+      goals: player.G,
+      assists: player.A,
+      points: player.Points,
+      plusMinus: player.PlusMinus,
+      pim: player.PIM,
+      shotsOnGoal: player.SOG,
+      hits: player.Hits,
+      blocks: player.Blocks,
+      faceoffs: player.FO,
+      faceoffWins: player.FOW,
+      fights: player.Fights,
+      fightWins: player.Fights_Won,
+      fightLosses: player.Fights - player.Fights_Won,
+      giveaways: player.GvA,
+      takeaways: player.TkA,
+      timeOnIce: player.TOI,
+      ppGoals: player.PPG,
+      ppAssists: player.PPA,
+      ppPoints: player.PPP,
+      shGoals: player.SHG,
+      shAssists: player.SHA,
+      shPoints: player.SHPoints,
+    };
+  });
+
+  res.status(200).json(parsed);
+};

--- a/pages/api/v1/players/stats/allTime.ts
+++ b/pages/api/v1/players/stats/allTime.ts
@@ -95,7 +95,7 @@ export default async (
       SUM(s.GP) AS GP,
       SUM(s.G) AS G,
       SUM(s.A) AS A,
-      SUM(s.G) + SUM(s.A) AS Points,
+      SUM(s.G + s.A) AS Points,
       SUM(s.GWG) AS GWG,
       SUM(s.TOI) AS TOI,
       SUM(s.GvA) AS GvA,
@@ -128,7 +128,7 @@ export default async (
     ON s.SeasonID = p.SeasonID 
    AND s.LeagueID = p.LeagueID
    AND s.PlayerID = p.PlayerID
-  INNER JOIN corrected_player_ratings AS r
+  INNER JOIN player_ratings AS r
     ON s.SeasonID = r.SeasonID 
    AND s.LeagueID = r.LeagueID
    AND s.PlayerID = r.PlayerID

--- a/pages/api/v1/teams/allTime.ts
+++ b/pages/api/v1/teams/allTime.ts
@@ -113,6 +113,11 @@ ORDER BY ${sortSql} ${orderSql};
 
   const teams = await query(search);
 
+  if ('error' in teams) {
+    res.status(500).send('Server Connection Failed');
+    return;
+  }
+
   if (teams.length === 0) {
     res.status(404).json({ message: 'No teams found' });
     return;

--- a/pages/api/v1/teams/allTime.ts
+++ b/pages/api/v1/teams/allTime.ts
@@ -50,7 +50,20 @@ export default async (
     endSeason,
   } = req.query;
 
-  const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.points;
+  if (startSeason != null && !validateSeason(startSeason as string)) {
+    res.status(400).json({ error: 'Invalid startSeason format' });
+    return;
+  }
+  if (endSeason != null && !validateSeason(endSeason as string)) {
+    res.status(400).json({ error: 'Invalid endSeason format' });
+    return;
+  }
+
+  const sortSql = SORTABLE_COLUMNS[sort];
+  if (!sortSql) {
+    res.status(400).json({ error: 'Invalid sort option. See API for options' });
+    return;
+  }
 
   let orderSql: string;
   if (order === 'asc') {

--- a/pages/api/v1/teams/allTime.ts
+++ b/pages/api/v1/teams/allTime.ts
@@ -27,13 +27,13 @@ export type TeamInfo = {
 };
 
 const SORTABLE_COLUMNS: Record<string, string> = {
-  points: 's.points DESC',
-  wins: 's.wins DESC',
-  losses: 's.losses DESC',
-  overtimeLosses: 's.overtimeLosses DESC',
-  goalsFor: 's.goalsFor DESC',
-  goalsAgainst: 's.goalsAgainst ASC',
-  winPercent: 's.winPercent DESC',
+  points: 's.points',
+  wins: 's.wins',
+  losses: 's.losses',
+  overtimeLosses: 's.overtimeLosses',
+  goalsFor: 's.goalsFor',
+  goalsAgainst: 's.goalsAgainst',
+  winPercent: 's.winPercent',
 };
 
 export default async (
@@ -42,9 +42,22 @@ export default async (
 ): Promise<void> => {
   await use(req, res, cors);
 
-  const { league = 0, sort, startSeason, endSeason } = req.query;
+  const {
+    league = 0,
+    sort,
+    order = 'desc',
+    startSeason,
+    endSeason,
+  } = req.query;
 
   const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.points;
+
+  let orderSql: string;
+  if (order === 'asc') {
+    orderSql = 'ASC';
+  } else {
+    orderSql = 'DESC';
+  }
 
   const search = SQL`
 SELECT
@@ -95,7 +108,7 @@ INNER JOIN (
 ) t
   ON s.TeamID = t.TeamID
   AND s.LeagueID = t.LeagueID`).append(`
-ORDER BY ${sortSql};
+ORDER BY ${sortSql} ${orderSql};
 `);
 
   const teams = await query(search);

--- a/pages/api/v1/teams/allTime.ts
+++ b/pages/api/v1/teams/allTime.ts
@@ -1,0 +1,108 @@
+// @ts-nocheck
+import Cors from 'cors';
+import { NextApiRequest, NextApiResponse } from 'next';
+import SQL from 'sql-template-strings';
+
+import { query } from '../../../../lib/db';
+import use from '../../../../lib/middleware';
+
+const cors = Cors({
+  methods: ['GET', 'HEAD'],
+});
+
+export type TeamInfo = {
+  id: number;
+  league: number;
+  name: string;
+  nickname: string;
+  wins: number;
+  losses: number;
+  overtimeLosses: number;
+  shootoutWins: number;
+  shootoutLosses: number;
+  points: number;
+  goalsFor: number;
+  goalsAgainst: number;
+  winPercent: number;
+};
+
+const SORTABLE_COLUMNS: Record<string, string> = {
+  points: 's.points DESC',
+  wins: 's.wins DESC',
+  losses: 's.losses DESC',
+  overtimeLosses: 's.overtimeLosses DESC',
+  goalsFor: 's.goalsFor DESC',
+  goalsAgainst: 's.goalsAgainst ASC',
+  winPercent: 's.winPercent DESC',
+};
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  await use(req, res, cors);
+
+  const { league = 0, sort, startSeason, endSeason } = req.query;
+
+  const sortSql = SORTABLE_COLUMNS[sort] || SORTABLE_COLUMNS.points;
+
+  const search = SQL`
+SELECT
+  s.TeamID AS id,
+  s.LeagueID AS league,
+  t.Name AS name,
+  t.Nickname AS nickname,
+  s.wins,
+  s.losses,
+  s.overtimeLosses,
+  s.shootoutWins,
+  s.shootoutLosses,
+  s.points,
+  s.goalsFor,
+  s.goalsAgainst,
+  ROUND(s.wins / NULLIF(s.wins + s.losses + s.overtimeLosses, 0), 3) AS winPercent
+FROM (
+  SELECT
+    TeamID,
+    LeagueID,
+    SUM(Wins) AS wins,
+    SUM(Losses) AS losses,
+    SUM(OTL) AS overtimeLosses,
+    SUM(SOW) AS shootoutWins,
+    SUM(SOL) AS shootoutLosses,
+    SUM(Points) AS points,
+    SUM(GF) AS goalsFor,
+    SUM(GA) AS goalsAgainst
+  FROM team_records
+  WHERE LeagueID = ${+league}`
+    .append(startSeason != null ? SQL` AND SeasonID >= ${+startSeason} ` : '')
+    .append(endSeason != null ? SQL` AND SeasonID <= ${+endSeason} ` : '')
+    .append(SQL`
+  GROUP BY TeamID, LeagueID
+) s
+INNER JOIN (
+  SELECT t1.TeamID, t1.LeagueID, t1.Name, t1.Nickname
+  FROM team_data AS t1
+  INNER JOIN (
+    SELECT TeamID, LeagueID, MAX(SeasonID) AS LatestSeason
+    FROM team_data
+    WHERE LeagueID = ${+league}
+    GROUP BY TeamID, LeagueID
+  ) AS latest
+    ON t1.TeamID = latest.TeamID
+    AND t1.LeagueID = latest.LeagueID
+    AND t1.SeasonID = latest.LatestSeason
+) t
+  ON s.TeamID = t.TeamID
+  AND s.LeagueID = t.LeagueID`).append(`
+ORDER BY ${sortSql};
+`);
+
+  const teams = await query(search);
+
+  if (teams.length === 0) {
+    res.status(404).json({ message: 'No teams found' });
+    return;
+  }
+  res.status(200).json(teams);
+};

--- a/public/docs.html
+++ b/public/docs.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title>SHL API Documentation</title>
-    <!-- needed for adaptive design -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
@@ -10,19 +9,150 @@
       rel="stylesheet"
     />
     <link rel="shortcut icon" href="/league_logos/SHL.svg" />
-
-    <!--
-    ReDoc doesn't change outer page styles
-    -->
     <style>
       body {
         margin: 0;
         padding: 0;
+        font-family: Roboto, sans-serif;
+      }
+      .version-selector {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 60px;
+        background: #2d3748;
+        display: flex;
+        align-items: center;
+        padding: 0 20px;
+        z-index: 100;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      }
+      .version-selector select {
+        padding: 8px 16px;
+        font-size: 16px;
+        border: 1px solid #4a5568;
+        border-radius: 4px;
+        background: #1a202c;
+        color: white;
+        margin-left: 10px;
+        cursor: pointer;
+      }
+      .version-selector label {
+        color: white;
+        font-weight: 500;
+      }
+      #redoc-container {
+        margin-top: 60px;
+      }
+      .loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 200px;
+        color: #666;
+        font-size: 16px;
       }
     </style>
   </head>
   <body>
-    <redoc spec-url="swagger.json"></redoc>
+    <div class="version-selector">
+      <label for="version">API Version:</label>
+      <select id="version" onchange="changeVersion(this.value)">
+        <option value="v1">Version 1</option>
+        <option value="v2">Version 2</option>
+        <option value="v3">Version 3</option>
+      </select>
+    </div>
+    <div id="redoc-container"></div>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+    <script>
+      let containerCounter = 0;
+
+      async function initDocs(version) {
+        const specs = {
+          v1: 'swagger.json',
+          v2: 'swagger-v2.json',
+          v3: 'swagger-v3.json',
+        };
+
+        try {
+          history.replaceState(null, null, '#' + version);
+          const mainContainer = document.getElementById('redoc-container');
+
+          mainContainer.innerHTML =
+            '<div class="loading">Loading API documentation...</div>';
+          const response = await fetch(specs[version]);
+          if (!response.ok) {
+            throw new Error(`Failed to load spec: ${response.status}`);
+          }
+          const spec = await response.json();
+
+          containerCounter++;
+          const newContainer = document.createElement('div');
+          newContainer.id = `redoc-instance-${containerCounter}`;
+
+          mainContainer.innerHTML = '';
+          mainContainer.appendChild(newContainer);
+
+          await Redoc.init(
+            spec,
+            {
+              scrollYOffset: 60, // Height of our version selector
+              theme: {
+                colors: {
+                  primary: {
+                    main: '#2d3748',
+                  },
+                },
+              },
+            },
+            newContainer,
+          );
+        } catch (err) {
+          console.error('Failed to load API spec:', err);
+          const container = document.getElementById('redoc-container');
+          container.innerHTML = `
+            <div class="loading" style="color: #e53e3e;">
+              Error loading API documentation: ${err.message}
+            </div>
+          `;
+        }
+      }
+
+      async function changeVersion(version) {
+        // Disable the select while loading
+        const select = document.getElementById('version');
+        select.disabled = true;
+
+        try {
+          // Initialize docs with new version
+          await initDocs(version);
+        } finally {
+          // Re-enable the select
+          select.disabled = false;
+        }
+      }
+
+      // Initial load
+      window.addEventListener('load', function () {
+        const hash = window.location.hash.slice(1);
+        const version = ['v1', 'v2', 'v3'].includes(hash) ? hash : 'v1';
+        document.getElementById('version').value = version;
+        initDocs(version);
+      });
+
+      // Handle browser back/forward navigation
+      window.addEventListener('hashchange', function () {
+        const hash = window.location.hash.slice(1);
+        if (['v1', 'v2', 'v3'].includes(hash)) {
+          const select = document.getElementById('version');
+          if (select.value !== hash) {
+            select.value = hash;
+            initDocs(hash);
+          }
+        }
+      });
+    </script>
   </body>
 </html>

--- a/public/swagger-v2.json
+++ b/public/swagger-v2.json
@@ -1,0 +1,970 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is the V2 API documentation for the Simulation Hockey League API. You can find out more about the SHL at [simulationhockey.com](https://simulationhockey.com/index.php).",
+    "version": "2.0.0",
+    "title": "Simulation Hockey League V2",
+    "contact": {
+      "email": "simulationhockeysite@gmail.com"
+    },
+    "license": {
+      "name": "MIT License",
+      "url": "https://mit-license.org/"
+    }
+  },
+  "host": "index.simulationhockey.com",
+  "basePath": "/api/v2",
+  "tags": [
+    {
+      "name": "schedule",
+      "description": "Game schedule and stats"
+    }
+  ],
+  "schemes": ["https", "http"],
+  "paths": {
+    "/schedule/game/boxscore/summary": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get game boxscore summary",
+        "description": "Returns a summary of the game including period scores, shots, team stats, and three stars",
+        "operationId": "getBoxscoreSummary",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BoxscoreSummary"
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/boxscore/skaters": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get boxscore skater stats",
+        "description": "Returns detailed statistics for all skaters in the game",
+        "operationId": "getBoxscoreSkaters",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "away": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BoxscoreSkater"
+                  }
+                },
+                "home": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BoxscoreSkater"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/boxscore/penalties": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get boxscore penalties",
+        "description": "Returns all penalties called in the game",
+        "operationId": "getBoxscorePenalties",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/BoxscorePenalty"
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/skaterStats": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get skater statistics",
+        "description": "Returns basic statistics for all skaters on both teams",
+        "operationId": "getSkaterStats",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "season",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "Season ID"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "League ID"
+          },
+          {
+            "name": "away",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "Away team ID"
+          },
+          {
+            "name": "home",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "Home team ID"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": ["Pre-Season", "Regular Season", "Playoffs"],
+            "description": "Season type"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "away": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/SkaterStats"
+                  }
+                },
+                "home": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/SkaterStats"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/previousMatchups": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get previous matchups between teams",
+        "description": "Returns a list of previous games played between two teams in the current season",
+        "operationId": "getPreviousMatchups",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "season",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "Season ID"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "League ID"
+          },
+          {
+            "name": "away",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "Away team ID"
+          },
+          {
+            "name": "home",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "Home team ID"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "enum": ["Pre-Season", "Regular Season", "Playoffs"],
+            "description": "Season type"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Game"
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/preview": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get game preview information",
+        "description": "Returns detailed game preview information including team identities and stats",
+        "operationId": "getGamePreview",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameId",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Game slug identifier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GamePreviewData"
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/boxscore/scoring": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get boxscore scoring details",
+        "description": "Returns all goals scored in the game with scorer and assist information",
+        "operationId": "getBoxscoreScoring",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/BoxscoreScoring"
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/goalieStats": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get goalie stats for a game",
+        "description": "Returns goalie statistics for both teams in a game",
+        "operationId": "getGameGoalieStats",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "season",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "away",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "Away team ID"
+          },
+          {
+            "name": "home",
+            "in": "query",
+            "required": true,
+            "type": "number",
+            "description": "Home team ID"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Season type (regular, playoffs, etc)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "away": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/GoalieGameStats"
+                  }
+                },
+                "home": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/GoalieGameStats"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/boxscore/goalies": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get boxscore goalie stats",
+        "description": "Returns detailed goalie statistics from a game's boxscore",
+        "operationId": "getBoxscoreGoalies",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "away": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BoxscoreGoalie"
+                  }
+                },
+                "home": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BoxscoreGoalie"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "BoxscoreSummary": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "object",
+          "properties": {
+            "home": {
+              "$ref": "#/definitions/TeamSummaryStats"
+            },
+            "away": {
+              "$ref": "#/definitions/TeamSummaryStats"
+            }
+          }
+        },
+        "stars": {
+          "type": "object",
+          "properties": {
+            "star1": {
+              "$ref": "#/definitions/StarPlayer"
+            },
+            "star2": {
+              "$ref": "#/definitions/StarPlayer"
+            },
+            "star3": {
+              "$ref": "#/definitions/StarPlayer"
+            }
+          }
+        },
+        "periodByPeriodStats": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "home": {
+                "type": "object",
+                "properties": {
+                  "goals": {
+                    "type": "number"
+                  },
+                  "shots": {
+                    "type": "number"
+                  }
+                }
+              },
+              "away": {
+                "type": "object",
+                "properties": {
+                  "goals": {
+                    "type": "number"
+                  },
+                  "shots": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "TeamSummaryStats": {
+      "type": "object",
+      "properties": {
+        "shots": {
+          "type": "number",
+          "example": 32
+        },
+        "pim": {
+          "type": "number",
+          "example": 8
+        },
+        "hits": {
+          "type": "number",
+          "example": 24
+        },
+        "giveaways": {
+          "type": "number",
+          "example": 12
+        },
+        "takeaways": {
+          "type": "number",
+          "example": 8
+        },
+        "faceoffWins": {
+          "type": "number",
+          "example": 28
+        },
+        "powerPlayGoals": {
+          "type": "number",
+          "example": 1
+        },
+        "powerPlayOpportunities": {
+          "type": "number",
+          "example": 3
+        }
+      }
+    },
+    "StarPlayer": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "example": 123
+        },
+        "name": {
+          "type": "string",
+          "example": "John Smith"
+        },
+        "team": {
+          "type": "number",
+          "example": 1
+        }
+      }
+    },
+    "BoxscoreSkater": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "John Smith"
+        },
+        "id": {
+          "type": "number",
+          "example": 123
+        },
+        "goals": {
+          "type": "number",
+          "example": 1
+        },
+        "assists": {
+          "type": "number",
+          "example": 2
+        },
+        "plusMinus": {
+          "type": "number",
+          "example": 1
+        },
+        "pim": {
+          "type": "number",
+          "example": 2
+        },
+        "shots": {
+          "type": "number",
+          "example": 4
+        },
+        "faceoffs": {
+          "type": "number",
+          "example": 15
+        },
+        "faceoffWins": {
+          "type": "number",
+          "example": 9
+        },
+        "hits": {
+          "type": "number",
+          "example": 3
+        },
+        "blocks": {
+          "type": "number",
+          "example": 2
+        },
+        "giveaways": {
+          "type": "number",
+          "example": 1
+        },
+        "takeaways": {
+          "type": "number",
+          "example": 2
+        },
+        "timeOnIce": {
+          "type": "string",
+          "example": "18:45"
+        },
+        "ppTimeOnIce": {
+          "type": "string",
+          "example": "02:30"
+        },
+        "shTimeOnIce": {
+          "type": "string",
+          "example": "01:45"
+        },
+        "shifts": {
+          "type": "number",
+          "example": 22
+        },
+        "gameRating": {
+          "type": "number",
+          "example": 85
+        },
+        "offensiveGameRating": {
+          "type": "number",
+          "example": 82
+        },
+        "defensiveGameRating": {
+          "type": "number",
+          "example": 88
+        }
+      }
+    },
+    "BoxscorePenalty": {
+      "type": "object",
+      "properties": {
+        "period": {
+          "type": "number",
+          "example": 1
+        },
+        "time": {
+          "type": "number",
+          "example": 840
+        },
+        "readableTime": {
+          "type": "string",
+          "example": "14:00"
+        },
+        "teamAbbr": {
+          "type": "string",
+          "example": "BUF"
+        },
+        "player": {
+          "type": "string",
+          "example": "Smith"
+        },
+        "reason": {
+          "type": "string",
+          "example": "Tripping"
+        },
+        "length": {
+          "type": "number",
+          "example": 2
+        }
+      }
+    },
+    "BoxscoreScoring": {
+      "type": "object",
+      "properties": {
+        "period": {
+          "type": "number",
+          "example": 1
+        },
+        "time": {
+          "type": "number",
+          "example": 840
+        },
+        "readableTime": {
+          "type": "string",
+          "example": "14:00"
+        },
+        "teamAbbr": {
+          "type": "string",
+          "example": "BUF"
+        },
+        "scorer": {
+          "$ref": "#/definitions/ScoringPlayer"
+        },
+        "primaryAssist": {
+          "$ref": "#/definitions/ScoringPlayer"
+        },
+        "secondaryAssist": {
+          "$ref": "#/definitions/ScoringPlayer"
+        },
+        "goalType": {
+          "type": "string",
+          "enum": ["ES", "PP", "SH", "ES, ENG"],
+          "example": "ES"
+        }
+      }
+    },
+    "ScoringPlayer": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Smith"
+        },
+        "id": {
+          "type": "number",
+          "example": 123
+        }
+      }
+    },
+    "GamePreviewData": {
+      "type": "object",
+      "properties": {
+        "game": {
+          "$ref": "#/definitions/Game"
+        },
+        "teams": {
+          "type": "object",
+          "properties": {
+            "away": {
+              "$ref": "#/definitions/TeamIdentity"
+            },
+            "home": {
+              "$ref": "#/definitions/TeamIdentity"
+            }
+          }
+        },
+        "teamStats": {
+          "type": "object",
+          "properties": {
+            "away": {
+              "$ref": "#/definitions/TeamStats"
+            },
+            "home": {
+              "$ref": "#/definitions/TeamStats"
+            }
+          }
+        }
+      }
+    },
+    "Game": {
+      "type": "object",
+      "properties": {
+        "season": {
+          "type": "number",
+          "example": 69
+        },
+        "league": {
+          "type": "number",
+          "example": 0
+        },
+        "date": {
+          "type": "string",
+          "example": "2023-12-25"
+        },
+        "homeTeam": {
+          "type": "number",
+          "example": 1
+        },
+        "homeScore": {
+          "type": "number",
+          "example": 3
+        },
+        "awayTeam": {
+          "type": "number",
+          "example": 2
+        },
+        "awayScore": {
+          "type": "number",
+          "example": 2
+        },
+        "type": {
+          "type": "string",
+          "example": "Regular Season"
+        },
+        "played": {
+          "type": "number",
+          "example": 1
+        },
+        "overtime": {
+          "type": "number",
+          "example": 0
+        },
+        "shootout": {
+          "type": "number",
+          "example": 0
+        },
+        "slug": {
+          "type": "string",
+          "example": "S69-L0-RS-1-BUF-TOR"
+        },
+        "gameid": {
+          "type": "number",
+          "example": 12345
+        }
+      }
+    },
+    "TeamIdentity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Toronto"
+        },
+        "nickname": {
+          "type": "string",
+          "example": "Maple Leafs"
+        },
+        "abbr": {
+          "type": "string",
+          "example": "TOR"
+        },
+        "primaryColor": {
+          "type": "string",
+          "example": "#00205B"
+        }
+      }
+    },
+    "TeamStats": {
+      "type": "object",
+      "properties": {
+        "gamesPlayed": {
+          "type": "number",
+          "example": 82
+        },
+        "goalsFor": {
+          "type": "number",
+          "example": 245
+        },
+        "goalsAgainst": {
+          "type": "number",
+          "example": 220
+        },
+        "record": {
+          "type": "string",
+          "example": "45-30-7"
+        }
+      }
+    },
+    "SkaterStats": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Smith"
+        },
+        "goals": {
+          "type": "number",
+          "example": 25
+        },
+        "assists": {
+          "type": "number",
+          "example": 40
+        },
+        "plusMinus": {
+          "type": "number",
+          "example": 15
+        }
+      }
+    },
+    "GoalieGameStats": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "John Smith"
+        },
+        "wins": {
+          "type": "number",
+          "example": 10
+        },
+        "losses": {
+          "type": "number",
+          "example": 5
+        },
+        "OT": {
+          "type": "number",
+          "example": 2
+        },
+        "GAA": {
+          "type": "number",
+          "format": "float",
+          "example": 2.45
+        },
+        "savePct": {
+          "type": "number",
+          "format": "float",
+          "example": 0.923
+        },
+        "shutouts": {
+          "type": "number",
+          "example": 3
+        }
+      }
+    },
+    "BoxscoreGoalie": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "example": 123
+        },
+        "name": {
+          "type": "string",
+          "example": "John Smith"
+        },
+        "shotsAgainst": {
+          "type": "number",
+          "example": 32
+        },
+        "goalsAgainst": {
+          "type": "number",
+          "example": 2
+        },
+        "saves": {
+          "type": "number",
+          "example": 30
+        },
+        "savePct": {
+          "type": "number",
+          "format": "float",
+          "example": 0.938
+        },
+        "pim": {
+          "type": "number",
+          "example": 2
+        },
+        "gameRating": {
+          "type": "number",
+          "example": 85
+        },
+        "minutesPlayed": {
+          "type": "string",
+          "example": "60:00"
+        }
+      }
+    }
+  }
+}

--- a/public/swagger-v3.json
+++ b/public/swagger-v3.json
@@ -1,0 +1,674 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is the V3 API documentation for the Simulation Hockey League API. You can find out more about the SHL at [simulationhockey.com](https://simulationhockey.com/index.php).",
+    "version": "3.0.0",
+    "title": "Simulation Hockey League V3",
+    "contact": {
+      "email": "simulationhockeysite@gmail.com"
+    },
+    "license": {
+      "name": "MIT License",
+      "url": "https://mit-license.org/"
+    }
+  },
+  "host": "index.simulationhockey.com",
+  "basePath": "/api/v3",
+  "tags": [
+    {
+      "name": "schedule",
+      "description": "Game schedule and stats"
+    }
+  ],
+  "schemes": ["https", "http"],
+  "paths": {
+    "/schedule/game/boxscore/summary": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get game boxscore summary",
+        "description": "Returns a summary of the game including period scores, shots, team stats, shot quality metrics, and three stars",
+        "operationId": "getBoxscoreSummary",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/BoxscoreSummary"
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/boxscore/goalies": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get boxscore goalie stats",
+        "description": "Returns detailed goalie statistics from a game's boxscore",
+        "operationId": "getBoxscoreGoalies",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "away": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BoxscoreGoalie"
+                  }
+                },
+                "home": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BoxscoreGoalie"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/boxscore/scoring": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get boxscore scoring details",
+        "description": "Returns all goals scored in the game with scorer and assist information including shot quality metrics",
+        "operationId": "getBoxscoreScoring",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/BoxscoreScoring"
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    },
+    "/schedule/game/boxscore/skaters": {
+      "get": {
+        "tags": ["schedule"],
+        "summary": "Get boxscore skater stats",
+        "description": "Returns detailed statistics for all skaters in the game including on/off ice stats, zone starts, and shot quality metrics",
+        "operationId": "getBoxscoreSkaters",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "gameid",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          },
+          {
+            "name": "league",
+            "in": "query",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "away": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BoxscoreSkater"
+                  }
+                },
+                "home": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BoxscoreSkater"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing arguments or server error"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "BoxscoreSummary": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "object",
+          "properties": {
+            "home": {
+              "$ref": "#/definitions/TeamSummaryStats"
+            },
+            "away": {
+              "$ref": "#/definitions/TeamSummaryStats"
+            }
+          }
+        },
+        "stars": {
+          "type": "object",
+          "properties": {
+            "star1": {
+              "$ref": "#/definitions/StarPlayer"
+            },
+            "star2": {
+              "$ref": "#/definitions/StarPlayer"
+            },
+            "star3": {
+              "$ref": "#/definitions/StarPlayer"
+            }
+          }
+        },
+        "periodByPeriodStats": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "home": {
+                "type": "object",
+                "properties": {
+                  "goals": {
+                    "type": "number"
+                  },
+                  "shots": {
+                    "type": "number"
+                  }
+                }
+              },
+              "away": {
+                "type": "object",
+                "properties": {
+                  "goals": {
+                    "type": "number"
+                  },
+                  "shots": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "TeamSummaryStats": {
+      "type": "object",
+      "properties": {
+        "shots": {
+          "type": "number",
+          "example": 32
+        },
+        "shot_attempts": {
+          "type": "number",
+          "description": "Total shot attempts including blocked and missed shots",
+          "example": 45
+        },
+        "pim": {
+          "type": "number",
+          "example": 8
+        },
+        "hits": {
+          "type": "number",
+          "example": 24
+        },
+        "giveaways": {
+          "type": "number",
+          "example": 12
+        },
+        "takeaways": {
+          "type": "number",
+          "example": 8
+        },
+        "faceoffWins": {
+          "type": "number",
+          "example": 28
+        },
+        "powerPlayGoals": {
+          "type": "number",
+          "example": 1
+        },
+        "powerPlayOpportunities": {
+          "type": "number",
+          "example": 3
+        },
+        "sq0": {
+          "type": "number",
+          "description": "Shot quality tier 0 (lowest quality) shots",
+          "example": 10
+        },
+        "sq1": {
+          "type": "number",
+          "description": "Shot quality tier 1 shots",
+          "example": 12
+        },
+        "sq2": {
+          "type": "number",
+          "description": "Shot quality tier 2 shots",
+          "example": 8
+        },
+        "sq3": {
+          "type": "number",
+          "description": "Shot quality tier 3 shots",
+          "example": 5
+        },
+        "sq4": {
+          "type": "number",
+          "description": "Shot quality tier 4 (highest quality) shots",
+          "example": 2
+        }
+      }
+    },
+    "BoxscoreScoring": {
+      "type": "object",
+      "properties": {
+        "period": {
+          "type": "number",
+          "example": 1
+        },
+        "time": {
+          "type": "number",
+          "example": 840
+        },
+        "readableTime": {
+          "type": "string",
+          "example": "14:00"
+        },
+        "teamAbbr": {
+          "type": "string",
+          "example": "BUF"
+        },
+        "scorer": {
+          "$ref": "#/definitions/ScoringPlayer"
+        },
+        "primaryAssist": {
+          "$ref": "#/definitions/ScoringPlayer"
+        },
+        "secondaryAssist": {
+          "$ref": "#/definitions/ScoringPlayer"
+        },
+        "goalType": {
+          "type": "string",
+          "enum": ["ES", "PP", "SH", "ES, ENG"],
+          "example": "ES"
+        },
+        "shotQuality": {
+          "type": "number",
+          "description": "Shot quality tier (0-4) with 4 being highest quality",
+          "minimum": 0,
+          "maximum": 4,
+          "example": 2
+        }
+      }
+    },
+    "BoxscoreGoalie": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "John Smith"
+        },
+        "id": {
+          "type": "number",
+          "example": 123
+        },
+        "isHomeTeam": {
+          "type": "number",
+          "enum": [0, 1],
+          "example": 1
+        },
+        "teamID": {
+          "type": "number",
+          "example": 1
+        },
+        "shotsAgainst": {
+          "type": "number",
+          "example": 32
+        },
+        "goalsAgainst": {
+          "type": "number",
+          "example": 2
+        },
+        "saves": {
+          "type": "number",
+          "example": 30
+        },
+        "savePct": {
+          "type": "number",
+          "format": "float",
+          "example": 0.938
+        },
+        "pim": {
+          "type": "number",
+          "example": 2
+        },
+        "gameRating": {
+          "type": "number",
+          "example": 85
+        },
+        "minutesPlayed": {
+          "type": "string",
+          "example": "60:00"
+        }
+      }
+    },
+    "ScoringPlayer": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "Smith"
+        },
+        "id": {
+          "type": "number",
+          "example": 123
+        }
+      }
+    },
+    "StarPlayer": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "example": 123
+        },
+        "name": {
+          "type": "string",
+          "example": "John Smith"
+        },
+        "team": {
+          "type": "number",
+          "example": 1
+        }
+      }
+    },
+    "BoxscoreSkater": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "John Smith"
+        },
+        "id": {
+          "type": "number",
+          "example": 123
+        },
+        "isHomeTeam": {
+          "type": "number",
+          "enum": [0, 1],
+          "example": 1
+        },
+        "teamID": {
+          "type": "number",
+          "example": 1
+        },
+        "goals": {
+          "type": "number",
+          "example": 1
+        },
+        "assists": {
+          "type": "number",
+          "example": 2
+        },
+        "plusMinus": {
+          "type": "number",
+          "example": 1
+        },
+        "pim": {
+          "type": "number",
+          "example": 2
+        },
+        "shots": {
+          "type": "number",
+          "example": 4
+        },
+        "faceoffs": {
+          "type": "number",
+          "example": 15
+        },
+        "faceoffWins": {
+          "type": "number",
+          "example": 9
+        },
+        "hits": {
+          "type": "number",
+          "example": 3
+        },
+        "blocks": {
+          "type": "number",
+          "example": 2
+        },
+        "giveaways": {
+          "type": "number",
+          "example": 1
+        },
+        "takeaways": {
+          "type": "number",
+          "example": 2
+        },
+        "timeOnIce": {
+          "type": "string",
+          "example": "18:45"
+        },
+        "ppTimeOnIce": {
+          "type": "string",
+          "example": "02:30"
+        },
+        "shTimeOnIce": {
+          "type": "string",
+          "example": "01:45"
+        },
+        "shifts": {
+          "type": "number",
+          "example": 22
+        },
+        "gameRating": {
+          "type": "number",
+          "example": 85
+        },
+        "offensiveGameRating": {
+          "type": "number",
+          "example": 82
+        },
+        "defensiveGameRating": {
+          "type": "number",
+          "example": 88
+        },
+        "team_shots_on": {
+          "type": "number",
+          "description": "Team shots on goal while player is on ice",
+          "example": 15
+        },
+        "team_shots_against_on": {
+          "type": "number",
+          "description": "Opponent shots on goal while player is on ice",
+          "example": 12
+        },
+        "team_shots_missed_on": {
+          "type": "number",
+          "description": "Team missed shots while player is on ice",
+          "example": 5
+        },
+        "team_shots_missed_against_on": {
+          "type": "number",
+          "description": "Opponent missed shots while player is on ice",
+          "example": 4
+        },
+        "team_shots_blocked_on": {
+          "type": "number",
+          "description": "Team shots blocked while player is on ice",
+          "example": 3
+        },
+        "team_shots_blocked_against_on": {
+          "type": "number",
+          "description": "Opponent shots blocked while player is on ice",
+          "example": 2
+        },
+        "team_goals_on": {
+          "type": "number",
+          "description": "Team goals while player is on ice",
+          "example": 2
+        },
+        "team_goals_against_on": {
+          "type": "number",
+          "description": "Opponent goals while player is on ice",
+          "example": 1
+        },
+        "team_shots_off": {
+          "type": "number",
+          "description": "Team shots on goal while player is off ice",
+          "example": 20
+        },
+        "team_shots_against_off": {
+          "type": "number",
+          "description": "Opponent shots on goal while player is off ice",
+          "example": 18
+        },
+        "team_shots_missed_off": {
+          "type": "number",
+          "description": "Team missed shots while player is off ice",
+          "example": 8
+        },
+        "team_shots_missed_against_off": {
+          "type": "number",
+          "description": "Opponent missed shots while player is off ice",
+          "example": 7
+        },
+        "team_shots_blocked_off": {
+          "type": "number",
+          "description": "Team shots blocked while player is off ice",
+          "example": 4
+        },
+        "team_shots_blocked_against_off": {
+          "type": "number",
+          "description": "Opponent shots blocked while player is off ice",
+          "example": 3
+        },
+        "team_goals_off": {
+          "type": "number",
+          "description": "Team goals while player is off ice",
+          "example": 1
+        },
+        "team_goals_against_off": {
+          "type": "number",
+          "description": "Opponent goals while player is off ice",
+          "example": 1
+        },
+        "oz_starts": {
+          "type": "number",
+          "description": "Offensive zone faceoff starts",
+          "example": 8
+        },
+        "nz_starts": {
+          "type": "number",
+          "description": "Neutral zone faceoff starts",
+          "example": 6
+        },
+        "dz_starts": {
+          "type": "number",
+          "description": "Defensive zone faceoff starts",
+          "example": 4
+        },
+        "team_oz_starts": {
+          "type": "number",
+          "description": "Team total offensive zone faceoff starts",
+          "example": 25
+        },
+        "team_nz_starts": {
+          "type": "number",
+          "description": "Team total neutral zone faceoff starts",
+          "example": 20
+        },
+        "team_dz_starts": {
+          "type": "number",
+          "description": "Team total defensive zone faceoff starts",
+          "example": 15
+        },
+        "sq0": {
+          "type": "number",
+          "description": "Shot quality tier 0 (lowest quality) shots",
+          "example": 1
+        },
+        "sq1": {
+          "type": "number",
+          "description": "Shot quality tier 1 shots",
+          "example": 2
+        },
+        "sq2": {
+          "type": "number",
+          "description": "Shot quality tier 2 shots",
+          "example": 1
+        },
+        "sq3": {
+          "type": "number",
+          "description": "Shot quality tier 3 shots",
+          "example": 0
+        },
+        "sq4": {
+          "type": "number",
+          "description": "Shot quality tier 4 (highest quality) shots",
+          "example": 0
+        }
+      }
+    }
+  }
+}

--- a/public/swagger.json
+++ b/public/swagger.json
@@ -1966,6 +1966,239 @@
         }
       }
     },
+    "/players/stats/allTime": {
+      "get": {
+        "tags": ["players"],
+        "summary": "Get Player All-Time Career Stats",
+        "description": "Returns career statistics for players across multiple seasons. Can be filtered by team, position, and season range.",
+        "operationId": "getPlayerAllTimeStats",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "league",
+            "in": "query",
+            "type": "number",
+            "default": 0,
+            "enum": [0, 1, 2, 3],
+            "description": "League ID to filter by"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "type": "string",
+            "default": "regular",
+            "enum": ["'preseason', 'regular', or 'playoffs'"],
+            "description": "'Pre-Season', 'Regular Season', or 'Playoffs'"
+          },
+          {
+            "name": "position",
+            "in": "query",
+            "type": "string",
+            "description": "Filter by position",
+            "enum": ["forward", "defenseman"]
+          },
+          {
+            "name": "seasonStart",
+            "in": "query",
+            "type": "number",
+            "description": "Start season for the aggregate data"
+          },
+          {
+            "name": "seasonEnd",
+            "in": "query",
+            "type": "number",
+            "description": "Start season for the aggregate data"
+          },
+          {
+            "name": "teamID",
+            "in": "query",
+            "type": "number",
+            "description": "Filter by teamID"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "type": "string",
+            "description": "Sort options",
+            "enum": [
+              "points,goals,assists,gamesPlayed,pim,hits,blocks,fights,fightWins,faceoffs,faceoffWins,ppGoals,ppAssists,ppPoints,shGoals,shAssists,shPoints,timeOnIce,giveaways,takeaways,plusMinus,shots"
+            ]
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "type": "string",
+            "enum": ["asc", "desc"],
+            "default": "desc",
+            "description": "Sort direction"
+          },
+          {
+            "name": "minGames",
+            "in": "query",
+            "type": "number",
+            "description": "Minimum games played to be included in results"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "number",
+            "description": "Limit the number of results returned"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/playerstats"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/goalies/stats/allTime": {
+      "get": {
+        "tags": ["goalies"],
+        "summary": "Get Goalie All-Time Career Stats",
+        "description": "Returns career statistics for goalies across multiple seasons. Can be filtered by team and season range.",
+        "operationId": "getGoalieAllTimeStats",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "league",
+            "in": "query",
+            "type": "number",
+            "default": 0,
+            "enum": [0, 1, 2, 3],
+            "description": "League ID to filter by"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "type": "string",
+            "default": "regular",
+            "enum": ["'preseason', 'regular', or 'playoffs'"],
+            "description": "'Pre-Season', 'Regular Season', or 'Playoffs'"
+          },
+          {
+            "name": "seasonStart",
+            "in": "query",
+            "type": "number",
+            "description": "Start season for the aggregate data"
+          },
+          {
+            "name": "seasonEnd",
+            "in": "query",
+            "type": "number",
+            "description": "Start season for the aggregate data"
+          },
+          {
+            "name": "teamID",
+            "in": "query",
+            "type": "number",
+            "description": "Filter by teamID"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "type": "string",
+            "description": "Sort options",
+            "enum": [
+              "wins,losses,ot,goalsAgainst,shutouts,savePct,gaa,minutes,gamesPlayed"
+            ]
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "type": "string",
+            "enum": ["asc", "desc"],
+            "default": "desc",
+            "description": "Sort direction"
+          },
+          {
+            "name": "minGames",
+            "in": "query",
+            "type": "number",
+            "description": "Minimum games played to be included in results"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "number",
+            "description": "Limit the number of results returned"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/goaliestats"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/allTime": {
+      "get": {
+        "tags": ["team"],
+        "summary": "Get Team All-Time Stats",
+        "description": "Returns team statistics aggregated across multiple seasons. Can be filtered by season range.",
+        "operationId": "getTeamAllTimeStats",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "league",
+            "in": "query",
+            "type": "number",
+            "default": 0,
+            "enum": [0, 1, 2, 3],
+            "description": "League ID to filter by"
+          },
+          {
+            "name": "seasonStart",
+            "in": "query",
+            "type": "number",
+            "description": "Start season for the aggregate data"
+          },
+          {
+            "name": "seasonEnd",
+            "in": "query",
+            "type": "number",
+            "description": "Start season for the aggregate data"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "type": "string",
+            "description": "Sort by field (points,wins,losses,overtimelosses,goalsFor,goalsAgainst,winPercentage)"
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "type": "string",
+            "enum": ["asc", "desc"],
+            "default": "desc",
+            "description": "Sort direction"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/standings"
+              }
+            }
+          }
+        }
+      }
+    },
     "/fantasy": {
       "get": {
         "tags": ["fantasy"],

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -17,3 +17,8 @@ export const portalQuery = async (uri: string) => {
   }
   return response.json();
 };
+
+export const validateSeason = (season: string): boolean => {
+  const seasonRegex = /^\d{2,3}$/; // rip season 1000
+  return seasonRegex.test(season);
+};


### PR DESCRIPTION
- 3 history related API's. Alltime for goalies, skaters, and allTeam. Hopefully in tandem with the eventual fixes to playerIDs. this can be used somewhere. 
- Added swagger docs to v2 and v3 api's. Majority of the additions are in that
- Updated the ReqDoc to handle all the versions of api to display to people
- 