### PR TITLE
Adding 2nd option for schedule, other changes

### DIFF
--- a/components/game/PreviousMatchups.tsx
+++ b/components/game/PreviousMatchups.tsx
@@ -2,8 +2,8 @@ import { Spinner } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import classnames from 'classnames';
 import { useRouter } from 'next/router';
+import { Game } from 'typings/api';
 
-import { Game } from '../../pages/api/v1/schedule';
 import { GamePreviewData } from '../../pages/api/v2/schedule/game/preview';
 import { League } from '../../utils/leagueHelpers';
 import { query } from '../../utils/query';

--- a/components/schedule/ScheduleDay.tsx
+++ b/components/schedule/ScheduleDay.tsx
@@ -1,4 +1,5 @@
-import { Game } from '../../pages/api/v1/schedule';
+import { Game } from 'typings/api';
+
 import { TeamInfo } from '../../pages/api/v1/teams';
 import { League } from '../../utils/leagueHelpers';
 

--- a/components/schedule/ScheduleGameMatchup.tsx
+++ b/components/schedule/ScheduleGameMatchup.tsx
@@ -1,8 +1,8 @@
 import classnames from 'classnames';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
+import { Game } from 'typings/api';
 
-import { Game } from '../../pages/api/v1/schedule';
 import { TeamInfo } from '../../pages/api/v1/teams';
 import { League } from '../../utils/leagueHelpers';
 import { onlyIncludeSeasonAndTypeInQuery } from '../../utils/routingHelpers';

--- a/components/tables/ScheduleTable.tsx
+++ b/components/tables/ScheduleTable.tsx
@@ -1,0 +1,255 @@
+import { ExternalLinkIcon } from '@chakra-ui/icons';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import classnames from 'classnames';
+import { useRouter } from 'next/router';
+import { TeamInfo } from 'pages/api/v1/teams';
+import { useMemo } from 'react';
+import { Game } from 'typings/api';
+
+import { League } from '../../utils/leagueHelpers';
+import { onlyIncludeSeasonAndTypeInQuery } from '../../utils/routingHelpers';
+import { Link } from '../common/Link';
+import { TeamLogo } from '../TeamLogo';
+
+import { Table } from './Table';
+import { GAMES_TABLE } from './tableBehavioralFlags';
+import { TableHeader } from './TableHeader';
+
+const columnHelper = createColumnHelper<Game>();
+
+export const ScheduleTable = ({
+  league,
+  data,
+  teams,
+  selectedTeamId,
+}: {
+  league: League;
+  data: Game[];
+  teams: TeamInfo[];
+  selectedTeamId: number;
+}) => {
+  const router = useRouter();
+
+  const teamsById = useMemo(
+    () => new Map(teams.map((t) => [t.id, t])),
+    [teams],
+  );
+
+  const rollingGames = useMemo(() => {
+    let wins = 0;
+    let losses = 0;
+    let otl = 0;
+
+    const sorted = [...data].sort((a, b) => {
+      const [aY, aM, aD] = a.date.split('-').map(Number);
+      const [bY, bM, bD] = b.date.split('-').map(Number);
+      return (
+        new Date(aY, aM - 1, aD).getTime() - new Date(bY, bM - 1, bD).getTime()
+      );
+    });
+
+    return sorted.map((game): Game => {
+      if (!game.played) return { ...game, wlOtl: undefined };
+
+      const isHome = game.homeTeam === selectedTeamId;
+      const teamScore = isHome ? game.homeScore : game.awayScore;
+      const oppScore = isHome ? game.awayScore : game.homeScore;
+      const won = teamScore > oppScore;
+      const isOtl = !won && (game.overtime || game.shootout);
+
+      if (won) wins++;
+      else if (isOtl) otl++;
+      else losses++;
+
+      return { ...game, wlOtl: `${wins}-${losses}-${otl}` };
+    });
+  }, [data, selectedTeamId]);
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor(
+        (row) => {
+          const [year, month, day] = row.date.split('-').map(Number);
+          return new Date(year, month - 1, day).getTime();
+        },
+        {
+          id: 'game-date',
+          header: () => <TableHeader title="Date">Date</TableHeader>,
+          sortDescFirst: true,
+          cell: ({ row }) => (
+            <span className="text-sm text-primary">{row.original.date}</span>
+          ),
+        },
+      ),
+      columnHelper.accessor(
+        (row) =>
+          row.homeTeam === selectedTeamId ? row.awayTeam : row.homeTeam,
+        {
+          id: 'opponent',
+          header: () => <TableHeader title="Opponent">Opponent</TableHeader>,
+          enableSorting: true,
+          cell: (props) => {
+            const opponentId = props.getValue();
+            const opponent = teamsById.get(opponentId);
+            const isHome = props.row.original.homeTeam === selectedTeamId;
+            return (
+              <div className="flex items-center gap-2 pr-4 md:pr-0">
+                <span className="w-4 text-xs text-secondary">
+                  {isHome ? 'vs' : '@'}
+                </span>
+                <Link
+                  href={{
+                    pathname: '/[league]/team/[id]',
+                    query: {
+                      ...onlyIncludeSeasonAndTypeInQuery(router.query),
+                      id: opponentId,
+                    },
+                  }}
+                  className="flex items-center gap-2"
+                >
+                  <TeamLogo
+                    league={league}
+                    teamAbbreviation={opponent?.abbreviation}
+                    aria-label={`${opponent?.name} logo`}
+                    className="size-[26px]"
+                  />
+                  <span className="inline text-left text-blue600 md:hidden">
+                    {opponent?.abbreviation}
+                  </span>
+                  <span className="mx-2.5 my-0 hidden min-w-max text-left text-blue600 md:inline">
+                    {opponent?.name}
+                  </span>
+                </Link>
+              </div>
+            );
+          },
+        },
+      ),
+      columnHelper.accessor(
+        ({ homeScore, awayScore, overtime, shootout, played, homeTeam }) => ({
+          homeScore,
+          awayScore,
+          overtime,
+          shootout,
+          played,
+          homeTeam,
+        }),
+        {
+          id: 'result',
+          header: () => <TableHeader title="Result">Result</TableHeader>,
+          enableSorting: false,
+          cell: (props) => {
+            const {
+              homeScore,
+              awayScore,
+              overtime,
+              shootout,
+              played,
+              homeTeam,
+            } = props.getValue();
+
+            if (!played) {
+              return <span className="text-sm text-tertiary">–</span>;
+            }
+
+            const isHome = homeTeam === selectedTeamId;
+            const teamScore = isHome ? homeScore : awayScore;
+            const oppScore = isHome ? awayScore : homeScore;
+            const won = teamScore > oppScore;
+            const tag = shootout ? 'SO' : overtime ? 'OT' : null;
+
+            return (
+              <div className="flex flex-col items-center gap-0.5">
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className={classnames(
+                      'flex size-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-bold',
+                      won
+                        ? 'bg-green500'
+                        : 'border border-secondary bg-secondary text-tertiary',
+                    )}
+                  >
+                    {won ? 'W' : 'L'}
+                  </span>
+                  <span className="text-sm font-medium text-primary">
+                    {teamScore}–{oppScore}
+                  </span>
+                </div>
+                {tag && (
+                  <span className="rounded bg-secondary px-1 py-0.5 text-center text-[10px] text-tertiary">
+                    {tag}
+                  </span>
+                )}
+              </div>
+            );
+          },
+        },
+      ),
+      columnHelper.accessor('wlOtl', {
+        id: 'wlOtl',
+        header: () => <TableHeader title="W-L-OTL">W-L-OTL</TableHeader>,
+        enableSorting: false,
+        cell: (props) => (
+          <span className="text-sm text-primary">
+            {props.getValue() ?? '–'}
+          </span>
+        ),
+      }),
+      columnHelper.accessor(
+        (row) => {
+          const [year, month, day] = row.date.split('-').map(Number);
+          return new Date(year, month - 1, day).getTime();
+        },
+        {
+          id: 'game-link',
+          header: () => <TableHeader title="Link">Link</TableHeader>,
+          enableSorting: false,
+          cell: ({ row }) => {
+            const { slug, season } = row.original;
+            return (
+              <Link
+                href={{
+                  pathname: '/[league]/[season]/game/[id]',
+                  query: {
+                    ...onlyIncludeSeasonAndTypeInQuery(router.query),
+                    id: slug,
+                    league,
+                    season: season.toString(),
+                  },
+                }}
+                className="flex items-center gap-1 text-sm text-blue600 hover:underline"
+                target="_blank"
+              >
+                Game <ExternalLinkIcon boxSize={3} />
+              </Link>
+            );
+          },
+        },
+      ),
+    ],
+    [league, router.query, teamsById, selectedTeamId],
+  );
+
+  const table = useReactTable({
+    columns,
+    data: rollingGames,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: {
+      pagination: {
+        pageSize: 66,
+        pageIndex: 0,
+      },
+      sorting: [{ id: 'game-date', desc: false }],
+    },
+  });
+
+  return <Table<Game> table={table} tableBehavioralFlags={GAMES_TABLE} />;
+};

--- a/components/tables/ScheduleTable.tsx
+++ b/components/tables/ScheduleTable.tsx
@@ -2,6 +2,7 @@ import { ExternalLinkIcon } from '@chakra-ui/icons';
 import {
   createColumnHelper,
   getCoreRowModel,
+  getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
@@ -85,6 +86,20 @@ export const ScheduleTable = ({
           cell: ({ row }) => (
             <span className="text-sm text-primary">{row.original.date}</span>
           ),
+        },
+      ),
+      columnHelper.accessor(
+        (row) => {
+          const opponentId =
+            row.homeTeam === selectedTeamId ? row.awayTeam : row.homeTeam;
+          return teamsById.get(opponentId)?.name ?? '';
+        },
+        {
+          id: 'opponent-name',
+          enableGlobalFilter: true,
+          enableSorting: false,
+          header: () => null,
+          cell: () => null,
         },
       ),
       columnHelper.accessor(
@@ -241,11 +256,15 @@ export const ScheduleTable = ({
     data: rollingGames,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     initialState: {
       pagination: {
         pageSize: 66,
         pageIndex: 0,
+      },
+      columnVisibility: {
+        'opponent-name': false,
       },
       sorting: [{ id: 'game-date', desc: false }],
     },

--- a/components/tables/tableBehavioralFlags.ts
+++ b/components/tables/tableBehavioralFlags.ts
@@ -16,6 +16,15 @@ export const TEAM_STATS_TABLE: TableBehavioralFlags = {
   showTableFilterOptions: false,
 };
 
+export const GAMES_TABLE: TableBehavioralFlags = {
+  stickyFirstColumn: false,
+  showTableFooter: false,
+  showCSVExportButton: true,
+  enablePagination: true,
+  enableFiltering: false,
+  showTableFilterOptions: false,
+};
+
 export const SKATER_TABLE_FLAGS = ({
   playerType,
   type,

--- a/components/tables/tableBehavioralFlags.ts
+++ b/components/tables/tableBehavioralFlags.ts
@@ -21,7 +21,7 @@ export const GAMES_TABLE: TableBehavioralFlags = {
   showTableFooter: false,
   showCSVExportButton: true,
   enablePagination: true,
-  enableFiltering: false,
+  enableFiltering: true,
   showTableFilterOptions: false,
 };
 

--- a/pages/[league]/schedule.tsx
+++ b/pages/[league]/schedule.tsx
@@ -1,9 +1,13 @@
-import { Checkbox, Spinner } from '@chakra-ui/react';
+import { DownloadIcon } from '@chakra-ui/icons';
+import { Checkbox, IconButton, Spinner } from '@chakra-ui/react';
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
+import { ScheduleTable } from 'components/tables/ScheduleTable';
 import { groupBy, isEmpty } from 'lodash';
 import { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
 import { useCallback, useMemo } from 'react';
+import { Game } from 'typings/api';
+import { downloadRowsAsCSV } from 'utils/tableHelpers';
 
 import { Select } from '../../components/common/Select';
 import { Footer } from '../../components/Footer';
@@ -15,7 +19,6 @@ import { useSeason } from '../../hooks/useSeason';
 import { useSeasonType } from '../../hooks/useSeasonType';
 import { League, leagueNameToId } from '../../utils/leagueHelpers';
 import { query } from '../../utils/query';
-import { Game } from '../api/v1/schedule';
 import { TeamInfo } from '../api/v1/teams';
 
 const getTeamsListData = async (league: League, season: number | undefined) => {
@@ -23,22 +26,31 @@ const getTeamsListData = async (league: League, season: number | undefined) => {
   return query(`api/v1/teams?league=${leagueNameToId(league)}${seasonParam}`);
 };
 
+type ViewMode = 'classic' | 'table';
+
 export default ({ league }: { league: League }) => {
   const { type } = useSeasonType();
   const { season, isSTHS } = useSeason();
 
+  const handleDownload = () => {
+    downloadRowsAsCSV(filteredGames, 'schedule');
+  };
+
   const {
     selectedTeam: currentSelectedTeam,
     unplayedOnly,
+    viewMode,
     setRouterPageState,
   } = useRouterPageState<{
     selectedTeam: string;
     unplayedOnly: 'false' | 'true';
+    viewMode: ViewMode;
   }>({
-    keys: ['selectedTeam', 'unplayedOnly'],
+    keys: ['selectedTeam', 'unplayedOnly', 'viewMode'],
     initialState: {
       selectedTeam: '-1',
       unplayedOnly: 'false',
+      viewMode: 'classic',
     },
   });
 
@@ -89,8 +101,8 @@ export default ({ league }: { league: League }) => {
     [setRouterPageState],
   );
 
-  const gamesByDate = useMemo(() => {
-    return groupBy(
+  const filteredGames = useMemo(() => {
+    return (
       data
         ?.filter((game) => unplayedOnly === 'false' || !game.played)
         .filter(
@@ -98,10 +110,13 @@ export default ({ league }: { league: League }) => {
             selectedTeam === -1 ||
             game.awayTeam === selectedTeam ||
             game.homeTeam === selectedTeam,
-        ),
-      (game) => game.date,
+        ) ?? []
     );
   }, [data, selectedTeam, unplayedOnly]);
+
+  const gamesByDate = useMemo(() => {
+    return groupBy(filteredGames, (game) => game.date);
+  }, [filteredGames]);
 
   return (
     <>
@@ -134,6 +149,21 @@ export default ({ league }: { league: League }) => {
                     optionsMap={teamSelectorMap}
                     className="!h-7 w-56"
                   />
+                  <div className="flex items-center overflow-hidden rounded border border-primary text-sm">
+                    {(['classic', 'table'] as ViewMode[]).map((mode) => (
+                      <button
+                        key={mode}
+                        onClick={() => setRouterPageState('viewMode', mode)}
+                        className={`px-3 py-1 capitalize transition-colors ${
+                          viewMode === mode
+                            ? 'bg-blue600'
+                            : 'bg-primary text-secondary hover:bg-secondary'
+                        }`}
+                      >
+                        {mode}
+                      </button>
+                    ))}
+                  </div>
                   <Checkbox
                     isChecked={unplayedOnly === 'true'}
                     onChange={() =>
@@ -146,38 +176,70 @@ export default ({ league }: { league: League }) => {
                   >
                     Hide Played Games
                   </Checkbox>
-                </div>
-                <div className="mx-auto mb-10 flex w-11/12 flex-wrap justify-evenly">
-                  {isEmpty(gamesByDate) && (
-                    <div className="mt-8 text-3xl font-bold">
-                      No games found
-                    </div>
+                  {viewMode === 'classic' && (
+                    <IconButton
+                      icon={<DownloadIcon />}
+                      variant="outline"
+                      aria-label="Download schedule as CSV"
+                      size="sm"
+                      onClick={handleDownload}
+                      isDisabled={!filteredGames.length}
+                    />
                   )}
-                  {Object.entries(gamesByDate)
-                    .sort((a, b) => {
-                      // NOTE: this is necessary since date parser on mobile requires the dates to follow ISO 8601 (ex. "2017-04-16")
-                      const [aYear, aMonth, aDate] = a[0]
-                        .split('-')
-                        .map((datePart) => parseInt(datePart));
-                      const [bYear, bMonth, bDate] = b[0]
-                        .split('-')
-                        .map((datePart) => parseInt(datePart));
-
-                      return (
-                        new Date(aYear, aMonth, aDate).getTime() -
-                        new Date(bYear, bMonth, bDate).getTime()
-                      );
-                    })
-                    .map(([date, games]) => (
-                      <ScheduleDay
-                        key={date}
-                        league={league}
-                        date={date}
-                        games={games}
-                        teamData={teamList}
-                      />
-                    ))}
                 </div>
+
+                {viewMode === 'table' ? (
+                  <div className="mx-auto mt-6 w-11/12">
+                    {selectedTeam === -1 ? (
+                      <div className="mt-8 text-3xl font-bold">
+                        Select a team to view the table
+                      </div>
+                    ) : isEmpty(filteredGames) ? (
+                      <div className="mt-8 text-3xl font-bold">
+                        No games found
+                      </div>
+                    ) : (
+                      <ScheduleTable
+                        league={league}
+                        data={filteredGames}
+                        teams={teamList}
+                        selectedTeamId={selectedTeam}
+                      />
+                    )}
+                  </div>
+                ) : (
+                  <div className="mx-auto mb-10 flex w-11/12 flex-wrap justify-evenly">
+                    {isEmpty(gamesByDate) && (
+                      <div className="mt-8 text-3xl font-bold">
+                        No games found
+                      </div>
+                    )}
+                    {Object.entries(gamesByDate)
+                      // NOTE: this is necessary since date parser on mobile requires the dates to follow ISO 8601 (ex. "2017-04-16")
+                      .sort((a, b) => {
+                        const [aYear, aMonth, aDate] = a[0]
+                          .split('-')
+                          .map((datePart) => parseInt(datePart));
+                        const [bYear, bMonth, bDate] = b[0]
+                          .split('-')
+                          .map((datePart) => parseInt(datePart));
+
+                        return (
+                          new Date(aYear, aMonth - 1, aDate).getTime() -
+                          new Date(bYear, bMonth - 1, bDate).getTime()
+                        );
+                      })
+                      .map(([date, games]) => (
+                        <ScheduleDay
+                          key={date}
+                          league={league}
+                          date={date}
+                          games={games}
+                          teamData={teamList}
+                        />
+                      ))}
+                  </div>
+                )}
               </>
             )}
           </>

--- a/pages/[league]/schedule.tsx
+++ b/pages/[league]/schedule.tsx
@@ -1,5 +1,6 @@
 import { DownloadIcon } from '@chakra-ui/icons';
 import { Checkbox, IconButton, Spinner } from '@chakra-ui/react';
+import { Tooltip } from '@chakra-ui/react';
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
 import { ScheduleTable } from 'components/tables/ScheduleTable';
 import { groupBy, isEmpty } from 'lodash';
@@ -151,17 +152,23 @@ export default ({ league }: { league: League }) => {
                   />
                   <div className="flex items-center overflow-hidden rounded border border-primary text-sm">
                     {(['classic', 'table'] as ViewMode[]).map((mode) => (
-                      <button
+                      <Tooltip
                         key={mode}
-                        onClick={() => setRouterPageState('viewMode', mode)}
-                        className={`px-3 py-1 capitalize transition-colors ${
-                          viewMode === mode
-                            ? 'bg-blue600'
-                            : 'bg-primary text-secondary hover:bg-secondary'
-                        }`}
+                        label="Select a team to use table view"
+                        isDisabled={!(mode === 'table' && selectedTeam === -1)}
                       >
-                        {mode}
-                      </button>
+                        <button
+                          onClick={() => setRouterPageState('viewMode', mode)}
+                          disabled={mode === 'table' && selectedTeam === -1}
+                          className={`px-3 py-1 capitalize transition-colors ${
+                            viewMode === mode
+                              ? 'bg-blue600'
+                              : 'bg-primary text-secondary hover:bg-secondary'
+                          } ${mode === 'table' && selectedTeam === -1 ? 'cursor-not-allowed opacity-50' : ''}`}
+                        >
+                          {mode}
+                        </button>
+                      </Tooltip>
                     ))}
                   </div>
                   <Checkbox

--- a/pages/api/v1/schedule/game/[gameId].ts
+++ b/pages/api/v1/schedule/game/[gameId].ts
@@ -2,8 +2,9 @@
 import Cors from 'cors';
 import { NextApiRequest, NextApiResponse } from 'next';
 import SQL from 'sql-template-strings';
+import { Game, GameRow } from 'typings/api';
 
-import { Game, convertGameRowToGame, GameRow } from '..';
+import { convertGameRowToGame } from '..';
 import { query } from '../../../../../lib/db';
 import use from '../../../../../lib/middleware';
 

--- a/pages/api/v1/schedule/index.ts
+++ b/pages/api/v1/schedule/index.ts
@@ -13,37 +13,6 @@ const cors = Cors({
 const seasonTypes = ['Pre-Season', 'Regular Season', 'Playoffs'] as const;
 export type SeasonType = typeof seasonTypes[number];
 
-export type GameRow = {
-  Slug: string;
-  SeasonID: number;
-  LeagueID: number;
-  Date: string;
-  Home: number;
-  HomeScore: number;
-  Away: number;
-  AwayScore: number;
-  Overtime: number;
-  Shootout: number;
-  Played: number;
-  Type: SeasonType;
-  GameID: number | null;
-};
-
-export type Game = {
-  slug: string;
-  season: number;
-  league: number;
-  date: string;
-  homeTeam: number;
-  homeScore: number;
-  awayTeam: number;
-  awayScore: number;
-  overtime: number;
-  shootout: number;
-  played: number;
-  type: SeasonType;
-  gameid: number | null;
-};
 
 export const convertGameRowToGame = (game: GameRow): Game => ({
   season: game.SeasonID,

--- a/pages/api/v2/schedule/game/preview.ts
+++ b/pages/api/v2/schedule/game/preview.ts
@@ -1,10 +1,10 @@
 import Cors from 'cors';
 import { NextApiRequest, NextApiResponse } from 'next';
 import SQL from 'sql-template-strings';
+import { Game } from 'typings/api';
 
 import { query } from '../../../../../lib/db';
 import use from '../../../../../lib/middleware';
-import { Game } from '../../../v1/schedule';
 import {
   TeamIdentity,
   TeamRecordRow,

--- a/pages/api/v2/schedule/game/previousMatchups.ts
+++ b/pages/api/v2/schedule/game/previousMatchups.ts
@@ -1,10 +1,11 @@
 import Cors from 'cors';
 import { NextApiRequest, NextApiResponse } from 'next';
 import SQL from 'sql-template-strings';
+import { GameRow } from 'typings/api';
 
 import { query } from '../../../../../lib/db';
 import use from '../../../../../lib/middleware';
-import { convertGameRowToGame, GameRow } from '../../../v1/schedule';
+import { convertGameRowToGame } from '../../../v1/schedule';
 
 const cors = Cors({
   methods: ['GET', 'HEAD'],

--- a/typings/api.d.ts
+++ b/typings/api.d.ts
@@ -413,3 +413,36 @@ export type PlayerNames = {
   PlayerID: number;
   Name: string;
 };
+
+export type GameRow = {
+  Slug: string;
+  SeasonID: number;
+  LeagueID: number;
+  Date: string;
+  Home: number;
+  HomeScore: number;
+  Away: number;
+  AwayScore: number;
+  Overtime: number;
+  Shootout: number;
+  Played: number;
+  Type: SeasonType;
+  GameID: number | null;
+};
+
+export type Game = {
+  slug: string;
+  season: number;
+  league: number;
+  date: string;
+  homeTeam: number;
+  homeScore: number;
+  awayTeam: number;
+  awayScore: number;
+  overtime: number;
+  shootout: number;
+  played: number;
+  type: SeasonType;
+  gameid: number | null;
+  wlOtl?: string;
+};

--- a/utils/tableHelpers.ts
+++ b/utils/tableHelpers.ts
@@ -10,19 +10,7 @@ export const downloadTableAsCSV = <T extends Record<string, unknown>>(
     .getFilteredRowModel()
     .rows.map(({ original }) => original);
 
-  const tableRowHeaders = Object.keys(tableRowData[0] ?? {});
-
-  const contents = stringify([
-    tableRowHeaders,
-    ...tableRowData.map((row) => Object.values(row ?? {})),
-  ]);
-
-  saveAs(
-    new Blob([contents], {
-      type: 'text/csv;charset=utf-8',
-    }),
-    `${label ?? 'shl-data'}.csv`,
-  );
+  downloadRowsAsCSV(tableRowData, label);
 };
 
 export const intToOrdinalNumberString = (num: number | undefined): string => {
@@ -44,4 +32,25 @@ export const intToOrdinalNumberString = (num: number | undefined): string => {
     default:
       return numString + 'th';
   }
+};
+
+export const downloadRowsAsCSV = <T extends Record<string, unknown>>(
+  rows: T[],
+  label?: string,
+): void => {
+  if (!rows.length) return;
+
+  const tableRowHeaders = Object.keys(rows[0]);
+
+  const contents = stringify([
+    tableRowHeaders,
+    ...rows.map((row) => Object.values(row)),
+  ]);
+
+  saveAs(
+    new Blob([contents], {
+      type: 'text/csv;charset=utf-8',
+    }),
+    `${label ?? 'shl-data'}.csv`,
+  );
 };


### PR DESCRIPTION
The goal for this PR is to add another option of viewing the schedule for teams. The classic way of viewing the schedule is good when you have a ton of teams and you want to view games that way. But it was always a bit clunky with individual teams. As you want more clarity on when you won or lost. So you ended up just counting things manually. 

What I did is add a 2nd view for a tanstack table to view the games. Following what ESPN does https://www.espn.com/nhl/team/schedule/_/name/det

To create a cleaner view of the schedule

What was also added
- Fixed bug where sometimes the game date sorting is inaccurate
- Moved more types to api.d.ts 
- In tableHelpers split up how we export csvs. Added another function downloadRowsAsCSV so that we can export things that are outside of tanstack tables
- Added download functionality to the schedule page as well. Gives the user the ability to download the schedule outside of using APIs
- Allow filtering on the table so people can view the games of a certain team
- 