### PR TITLE
New Line layout + smaller fixes

### DIFF
--- a/components/TeamLogo.tsx
+++ b/components/TeamLogo.tsx
@@ -383,6 +383,8 @@ const getLogoId = (
           return 'Canada_Red';
         case 'CAB':
           return 'Canada_Black';
+        case 'CZE':
+          return 'Czechia';
         case 'CZH':
           return 'Czechia';
         case 'DCH':

--- a/components/lines/Line.tsx
+++ b/components/lines/Line.tsx
@@ -147,10 +147,7 @@ export const Line = ({
   teamColors: TeamInfo['colors'];
 }) => {
   const lineEntries = useMemo(
-    () =>
-      Object.values(lines)
-        .slice(0, columns)
-        .filter((l) => l.LW || l.C || l.RW || l.LD || l.RD),
+    () => Object.values(lines).slice(0, columns),
     [lines, columns],
   );
 

--- a/components/lines/Line.tsx
+++ b/components/lines/Line.tsx
@@ -1,25 +1,136 @@
-import { useRef } from 'react';
-
-import { TeamLines } from '../../pages/api/v1/teams/[id]/lines';
+import { Box, Grid } from '@chakra-ui/react';
+import { TeamInfo } from 'pages/api/v1/teams';
+import { useMemo } from 'react';
+import {
+  AnyLine,
+  DEFENSE_POSITIONS,
+  FORWARD_POSITIONS,
+} from 'utils/playerHelpers';
 
 import { LinePlayer } from './LinePlayer';
 
-const LinePlayers = ({
-  lineup,
+const PositionGrid = ({
+  lineEntries,
+  teamColors,
 }: {
-  lineup: Partial<TeamLines['ES']['5on5']['L1']>;
+  lineEntries: AnyLine[];
+  teamColors: TeamInfo['colors'];
 }) => {
+  const activeFwdCols = FORWARD_POSITIONS.filter((p) =>
+    lineEntries.some((l) => l[p]),
+  );
+  const activeDefCols = DEFENSE_POSITIONS.filter((p) =>
+    lineEntries.some((l) => l[p]),
+  );
+
   return (
-    <div className="mx-auto mb-5 flex w-full flex-col items-center justify-center">
-      <div className="mb-5 flex w-full flex-row items-center justify-center">
-        {lineup.LW && <LinePlayer player={lineup.LW} position="LW" />}
-        {lineup.C && <LinePlayer player={lineup.C} position="C" />}
-        {lineup.RW && <LinePlayer player={lineup.RW} position="RW" />}
-      </div>
-      <div className="mb-5 flex w-full flex-row items-center justify-center">
-        {lineup.LD && <LinePlayer player={lineup.LD} position="LD" />}
-        {lineup.RD && <LinePlayer player={lineup.RD} position="RD" />}
-      </div>
+    <div className="flex flex-col gap-6">
+      {activeFwdCols.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <Grid
+            templateColumns={`2.5rem repeat(${activeFwdCols.length}, 1fr)`}
+            gap={1}
+          >
+            <Box />
+            {activeFwdCols.map((pos) => (
+              <div
+                key={pos}
+                className="text-center text-xs uppercase tracking-widest"
+              >
+                {pos}
+              </div>
+            ))}
+          </Grid>
+          {lineEntries.map((line, i) => (
+            <Grid
+              key={i}
+              templateColumns={`2.5rem repeat(${activeFwdCols.length}, 1fr)`}
+              gap={1}
+              alignItems="stretch"
+            >
+              <div className="text-xs">L{i + 1}</div>
+              {activeFwdCols.map((pos) => (
+                <Box key={pos}>
+                  {line[pos] ? (
+                    <LinePlayer
+                      player={line[pos]}
+                      className="w-full justify-center"
+                      teamColors={teamColors}
+                    />
+                  ) : (
+                    <div className="flex w-full items-center justify-center rounded-md border border-dashed border-grey200 py-3 text-xs">
+                      —
+                    </div>
+                  )}
+                </Box>
+              ))}
+            </Grid>
+          ))}
+        </div>
+      )}
+
+      {activeDefCols.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <Grid
+            templateColumns={`2.5rem repeat(${activeFwdCols.length}, 1fr)`}
+            gap={1}
+          >
+            <Box />
+            <Box
+              gridColumn={`2 / span ${activeFwdCols.length}`}
+              display="flex"
+              justifyContent={activeFwdCols.length === 3 ? 'center' : 'start'}
+              gap={2}
+            >
+              {activeDefCols.map((pos) => (
+                <div
+                  key={pos}
+                  className="w-1/3 text-center text-xs font-semibold uppercase"
+                >
+                  {pos}
+                </div>
+              ))}
+            </Box>
+          </Grid>
+          {lineEntries.map((line, i) => (
+            <Grid
+              key={i}
+              templateColumns={`2.5rem repeat(${activeFwdCols.length}, 1fr)`}
+              gap={1}
+              alignItems="stretch"
+            >
+              <div className="text-xs">L{i + 1}</div>
+              <Grid
+                gridColumn={`2 / span ${activeFwdCols.length}`}
+                templateColumns={`repeat(${activeDefCols.length}, 1fr)`}
+                gap={1}
+                w={
+                  activeFwdCols.length === 3
+                    ? `${(activeDefCols.length / 3) * 100}%`
+                    : 'full'
+                }
+                mx={activeFwdCols.length === 3 ? 'auto' : undefined}
+              >
+                {activeDefCols.map((pos) => (
+                  <Box key={pos}>
+                    {line[pos] ? (
+                      <LinePlayer
+                        player={line[pos]}
+                        className="w-full justify-center"
+                        teamColors={teamColors}
+                      />
+                    ) : (
+                      <div className="flex w-full items-center justify-center rounded-md border border-dashed py-3">
+                        —
+                      </div>
+                    )}
+                  </Box>
+                ))}
+              </Grid>
+            </Grid>
+          ))}
+        </div>
+      )}
     </div>
   );
 };
@@ -28,67 +139,29 @@ export const Line = ({
   type,
   lines,
   columns = 3,
+  teamColors,
 }: {
   type: string;
-  lines:
-    | TeamLines['ES'][Keys<TeamLines['ES']>]
-    | TeamLines['PP'][Keys<TeamLines['PP']>]
-    | TeamLines['PK'][Keys<TeamLines['PK']>];
+  lines: Record<string, AnyLine>;
   columns: 3 | 4;
+  teamColors: TeamInfo['colors'];
 }) => {
-  const ref = useRef<HTMLDivElement | null>(null);
+  const lineEntries = useMemo(
+    () =>
+      Object.values(lines)
+        .slice(0, columns)
+        .filter((l) => l.LW || l.C || l.RW || l.LD || l.RD),
+    [lines, columns],
+  );
+
+  if (!lineEntries.length) return null;
 
   return (
-    <>
-      <div className="m-auto w-2/5 border-b border-b-grey900 py-5 text-center font-mont text-3xl font-semibold">
+    <div className="mb-5">
+      <div className="mb-4 border-b border-b-grey200 pb-3 text-center font-mont text-2xl font-bold">
         {type.split('on').join(' on ')}
       </div>
-      <div className="m-auto flex w-full items-center justify-between px-2.5">
-        <div
-          className="m-5 cursor-pointer font-mont text-5xl"
-          onClick={() => {
-            if (!ref.current) return;
-
-            ref.current.scrollLeft -= ref.current.clientWidth;
-          }}
-        >
-          &lt;
-        </div>
-        <div
-          className="no-scrollbar mx-auto grid w-full snap-x snap-mandatory grid-flow-col overflow-y-hidden overflow-x-scroll scroll-smooth py-5"
-          style={{
-            gridTemplateColumns: `repeat(${columns}, 100%)`,
-            overscrollBehaviorX: 'contain',
-          }}
-          ref={ref}
-        >
-          {Object.values(lines).map((currLine, i) => {
-            if (i === columns) return null;
-            return (
-              <div
-                key={i}
-                className="flex w-full snap-center flex-col items-center justify-center"
-              >
-                <h4 className="mb-2.5 font-mont text-xl font-normal">
-                  {i + 1}
-                  {['st', 'nd', 'rd', 'th'][i]} Line
-                </h4>
-                <LinePlayers lineup={currLine} />
-              </div>
-            );
-          })}
-        </div>
-        <div
-          className="m-5 cursor-pointer font-mont text-5xl"
-          onClick={() => {
-            if (!ref.current) return;
-
-            ref.current.scrollLeft += ref.current.clientWidth;
-          }}
-        >
-          &gt;
-        </div>
-      </div>
-    </>
+      <PositionGrid lineEntries={lineEntries} teamColors={teamColors} />
+    </div>
   );
 };

--- a/components/lines/LinePlayer.tsx
+++ b/components/lines/LinePlayer.tsx
@@ -1,41 +1,50 @@
 import classnames from 'classnames';
 import { useRouter } from 'next/router';
-import React from 'react';
 
+import { TeamInfo } from '../../pages/api/v1/teams';
 import { getPlayerShortname } from '../../utils/playerHelpers';
 import { onlyIncludeSeasonAndTypeInQuery } from '../../utils/routingHelpers';
 import { Link } from '../common/Link';
 
 export const LinePlayer = ({
   player,
-  position,
+  teamColors,
+
   className,
 }: {
   player: { id: number; name: string } | undefined;
-  position: string;
+  teamColors: TeamInfo['colors'];
   className?: string;
 }) => {
   const router = useRouter();
+
+  if (!player) return null;
+
   return (
-    <div
+    <Link
+      href={{
+        pathname: '/[league]/player/[id]',
+        query: {
+          ...onlyIncludeSeasonAndTypeInQuery(router.query),
+          id: player.id,
+        },
+      }}
+      style={{
+        backgroundColor: teamColors.primary,
+        borderColor: teamColors.secondary,
+        color: teamColors.text,
+      }}
       className={classnames(
-        'mx-5 flex min-w-[200px] max-w-[350px] flex-col items-center justify-center overflow-hidden whitespace-nowrap rounded px-12 py-8 shadow-[0px_0px_15px_rgba(0,_0,_0,_0.1)]',
+        'flex min-h-[44px] h-full items-center justify-center gap-2 overflow-hidden rounded-md border px-3 py-3 transition-opacity hover:opacity-80',
         className,
       )}
     >
-      <Link
-        href={{
-          pathname: '/[league]/player/[id]',
-          query: {
-            ...onlyIncludeSeasonAndTypeInQuery(router.query),
-            id: player?.id,
-          },
-        }}
-        className="mb-2.5 inline-block text-ellipsis whitespace-nowrap text-lg font-bold transition-colors hover:text-blue600"
+      <span
+        className="text-center leading-tight text-xs sm:text-base font-bold"
+        style={{ color: teamColors.text }}
       >
-        {getPlayerShortname(player?.name ?? '')}
-      </Link>
-      <div className="text-base font-semibold">{position}</div>
-    </div>
+        {getPlayerShortname(player.name)}
+      </span>
+    </Link>
   );
 };

--- a/components/lines/LinePlayer.tsx
+++ b/components/lines/LinePlayer.tsx
@@ -9,7 +9,6 @@ import { Link } from '../common/Link';
 export const LinePlayer = ({
   player,
   teamColors,
-
   className,
 }: {
   player: { id: number; name: string } | undefined;
@@ -35,12 +34,12 @@ export const LinePlayer = ({
         color: teamColors.text,
       }}
       className={classnames(
-        'flex min-h-[44px] h-full items-center justify-center gap-2 overflow-hidden rounded-md border px-3 py-3 transition-opacity hover:opacity-80',
+        'flex h-full min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-md border p-3 transition-opacity hover:opacity-80',
         className,
       )}
     >
       <span
-        className="text-center leading-tight text-xs sm:text-base font-bold"
+        className="text-center text-xs font-bold leading-tight sm:text-base"
         style={{ color: teamColors.text }}
       >
         {getPlayerShortname(player.name)}

--- a/components/lines/Lines.tsx
+++ b/components/lines/Lines.tsx
@@ -8,6 +8,13 @@ import { Line } from './Line';
 import { LinePlayer } from './LinePlayer';
 import { SpecialTeamsLines } from './SpecialTeams';
 
+const linesDisplays = [
+  'Even Strength',
+  'Power Play',
+  'Penalty Kill',
+  'Misc',
+] as const;
+
 export const Lines = ({
   league,
   lines,
@@ -20,10 +27,9 @@ export const Lines = ({
   return (
     <Tabs>
       <TabList>
-        <Tab>Even Strength</Tab>
-        <Tab>Power Play</Tab>
-        <Tab>Penalty Kill</Tab>
-        <Tab>Other</Tab>
+        {linesDisplays.map((name) => (
+          <Tab key={name}>{name}</Tab>
+        ))}
       </TabList>
       <TabPanels>
         <TabPanel>
@@ -69,10 +75,10 @@ export const Lines = ({
         </TabPanel>
 
         <TabPanel>
-          {Object.entries(lines.PP).map(([situationType, group]) => (
+          {Object.entries(lines.PP).map(([lineType, group]) => (
             <SpecialTeamsLines
-              key={situationType}
-              situationType={situationType}
+              key={lineType}
+              situationType={lineType}
               group={group}
               teamColors={teamColors}
             />
@@ -80,10 +86,10 @@ export const Lines = ({
         </TabPanel>
 
         <TabPanel>
-          {Object.entries(lines.PK).map(([situationType, group]) => (
+          {Object.entries(lines.PK).map(([lineType, group]) => (
             <SpecialTeamsLines
-              key={situationType}
-              situationType={situationType}
+              key={lineType}
+              situationType={lineType}
               group={group}
               teamColors={teamColors}
             />

--- a/components/lines/Lines.tsx
+++ b/components/lines/Lines.tsx
@@ -1,105 +1,126 @@
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
+import { TeamInfo } from 'pages/api/v1/teams';
 
 import { TeamLines } from '../../pages/api/v1/teams/[id]/lines';
 import { isMainLeague, League } from '../../utils/leagueHelpers';
 
 import { Line } from './Line';
 import { LinePlayer } from './LinePlayer';
-
-const linesDisplays = [
-  'Even Strength',
-  'Power Play',
-  'Penalty Kill',
-  'Goalies',
-  'Other',
-] as const;
+import { SpecialTeamsLines } from './SpecialTeams';
 
 export const Lines = ({
   league,
   lines,
+  teamColors,
 }: {
   league: League;
   lines: TeamLines;
+  teamColors: TeamInfo['colors'];
 }) => {
   return (
     <Tabs>
       <TabList>
-        {linesDisplays.map((name) => (
-          <Tab key={name}>{name}</Tab>
-        ))}
+        <Tab>Even Strength</Tab>
+        <Tab>Power Play</Tab>
+        <Tab>Penalty Kill</Tab>
+        <Tab>Other</Tab>
       </TabList>
       <TabPanels>
         <TabPanel>
-          {Object.entries(lines.ES).map(([lineType, group]) => (
-            <Line
-              key={lineType}
-              type={lineType}
-              lines={group}
-              columns={!isMainLeague(league) ? 4 : 3}
-            />
-          ))}
-        </TabPanel>
-        <TabPanel>
-          {Object.entries(lines.PP).map(([lineType, group]) => (
-            <Line
-              key={lineType}
-              type={lineType}
-              lines={group}
-              columns={!isMainLeague(league) ? 4 : 3}
-            />
-          ))}
-        </TabPanel>
-        <TabPanel>
-          {Object.entries(lines.PK).map(([lineType, group]) => (
-            <Line
-              key={lineType}
-              type={lineType}
-              lines={group}
-              columns={!isMainLeague(league) ? 4 : 3}
-            />
-          ))}
-        </TabPanel>
-        <TabPanel>
-          <div className="flex w-full items-center justify-center">
-            <LinePlayer
-              player={lines.goalies.starter}
-              position="Starter"
-              className="flex-1"
-            />
-            <LinePlayer
-              player={lines.goalies.backup}
-              position="Backup"
-              className="flex-1"
-            />
-          </div>
-        </TabPanel>
-        <TabPanel>
-          <div className="flex w-full items-start justify-evenly gap-5">
-            <div className="flex flex-1 flex-col items-center justify-center gap-5">
-              <h3 className="text-2xl font-bold">Shootout Order</h3>
-              {lines.shootout
-                .filter((player) => !!player)
-                .map((player, i) => (
-                  <LinePlayer
-                    key={i}
-                    player={player}
-                    position={`Shootout ${i + 1}`}
-                    className="w-full"
-                  />
-                ))}
+          {Object.entries(lines.ES)
+            .filter(([lineType]) => lineType === '5on5')
+            .map(([lineType, group]) => (
+              <Line
+                key={lineType}
+                type={lineType}
+                lines={group}
+                columns={!isMainLeague(league) ? 4 : 3}
+                teamColors={teamColors}
+              />
+            ))}
+
+          <div className="mt-4 flex w-full flex-col items-center gap-3">
+            <h3 className="text-lg font-bold text-primary">Goalies</h3>
+            <div className="flex w-full max-w-md gap-3 py-3">
+              <LinePlayer
+                player={lines.goalies.starter}
+                className="flex-1 justify-center"
+                teamColors={teamColors}
+              />
+              <LinePlayer
+                player={lines.goalies.backup}
+                className="flex-1 justify-center"
+                teamColors={teamColors}
+              />
             </div>
-            <div className="flex w-1/2 flex-col items-center justify-center gap-5">
-              <h3 className="text-2xl font-bold">Extra Attackers</h3>
-              {lines.extraAttackers
-                .filter((player) => !!player)
-                .map((player, i) => (
-                  <LinePlayer
-                    key={i}
-                    player={player}
-                    position="Extra Attacker"
-                    className="w-full"
-                  />
-                ))}
+          </div>
+
+          {Object.entries(lines.ES)
+            .filter(([lineType]) => lineType !== '5on5')
+            .map(([lineType, group]) => (
+              <Line
+                key={lineType}
+                type={lineType}
+                lines={group}
+                columns={!isMainLeague(league) ? 4 : 3}
+                teamColors={teamColors}
+              />
+            ))}
+        </TabPanel>
+
+        <TabPanel>
+          {Object.entries(lines.PP).map(([situationType, group]) => (
+            <SpecialTeamsLines
+              key={situationType}
+              situationType={situationType}
+              group={group}
+              teamColors={teamColors}
+            />
+          ))}
+        </TabPanel>
+
+        <TabPanel>
+          {Object.entries(lines.PK).map(([situationType, group]) => (
+            <SpecialTeamsLines
+              key={situationType}
+              situationType={situationType}
+              group={group}
+              teamColors={teamColors}
+            />
+          ))}
+        </TabPanel>
+
+        <TabPanel>
+          <div className="flex w-full flex-col gap-10 sm:flex-row sm:items-start sm:justify-evenly">
+            <div className="flex flex-1 flex-col items-center gap-3">
+              <h3 className="text-lg font-bold">Shootout Order</h3>
+              <div className="flex w-full flex-col gap-2">
+                {lines.shootout
+                  .filter((player) => !!player)
+                  .map((player, i) => (
+                    <LinePlayer
+                      key={i}
+                      player={player}
+                      className="w-full"
+                      teamColors={teamColors}
+                    />
+                  ))}
+              </div>
+            </div>
+            <div className="flex flex-1 flex-col items-center gap-3">
+              <h3 className="text-lg font-bold">Extra Attackers</h3>
+              <div className="flex w-full flex-col gap-2">
+                {lines.extraAttackers
+                  .filter((player) => !!player)
+                  .map((player, i) => (
+                    <LinePlayer
+                      key={i}
+                      player={player}
+                      className="w-full"
+                      teamColors={teamColors}
+                    />
+                  ))}
+              </div>
             </div>
           </div>
         </TabPanel>

--- a/components/lines/SpecialTeams.tsx
+++ b/components/lines/SpecialTeams.tsx
@@ -1,0 +1,87 @@
+import { Box, Grid } from '@chakra-ui/react';
+import { TeamInfo } from 'pages/api/v1/teams';
+import {
+  AnyLine,
+  DEFENSE_POSITIONS,
+  FORWARD_POSITIONS,
+} from 'utils/playerHelpers';
+
+import { LinePlayer } from './LinePlayer';
+
+export const SpecialTeamsLines = ({
+  situationType,
+  group,
+  teamColors,
+}: {
+  situationType: string;
+  group: Record<string, AnyLine>;
+  teamColors: TeamInfo['colors'];
+}) => (
+  <div className="mb-5">
+    <div className="mb-4 border-b border-b-grey200 pb-3 text-center text-2xl font-bold">
+      {situationType.replace('on', ' on ')}
+    </div>
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {Object.values(group).map((unit, i) => (
+        <SpecialTeamsUnit
+          key={i}
+          unitNumber={i + 1}
+          line={unit}
+          teamColors={teamColors}
+        />
+      ))}
+    </div>
+  </div>
+);
+
+export const SpecialTeamsUnit = ({
+  unitNumber,
+  line,
+  teamColors,
+}: {
+  unitNumber: number;
+  line: AnyLine;
+  teamColors: TeamInfo['colors'];
+}) => {
+  const fwds = FORWARD_POSITIONS.filter((p) => line[p]);
+  const defs = DEFENSE_POSITIONS.filter((p) => line[p]);
+
+  if (!fwds.length && !defs.length) return null;
+
+  return (
+    <Box rounded="lg" p={4}>
+      <div className="mb-2 text-center text-sm font-bold">
+        Unit {unitNumber}
+      </div>
+      {fwds.length > 0 && (
+        <Grid templateColumns={`repeat(${fwds.length}, 1fr)`} gap={1} py={3}>
+          {fwds.map((pos) => (
+            <LinePlayer
+              key={pos}
+              player={line[pos]}
+              className="justify-center"
+              teamColors={teamColors}
+            />
+          ))}
+        </Grid>
+      )}
+      {defs.length > 0 && (
+        <Grid
+          templateColumns={`repeat(${defs.length}, 1fr)`}
+          gap={2}
+          width={fwds.length === 3 ? `${(defs.length / 3) * 100}%` : '100%'}
+          mx={fwds.length === 3 ? 'auto' : undefined}
+        >
+          {defs.map((pos) => (
+            <LinePlayer
+              key={pos}
+              player={line[pos]}
+              className="justify-center"
+              teamColors={teamColors}
+            />
+          ))}
+        </Grid>
+      )}
+    </Box>
+  );
+};

--- a/components/playoffBracket/DoubleBracket.tsx
+++ b/components/playoffBracket/DoubleBracket.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import classnames from 'classnames';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useSeason } from '../../hooks/useSeason';
 import {
@@ -38,6 +38,36 @@ export const DoubleBracket = ({
       );
     },
   });
+
+  const outerRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const [isScaled, setIsScaled] = useState(false);
+  const [scaledHeight, setScaledHeight] = useState<number | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    const recalc = () => {
+      if (!outerRef.current || !innerRef.current) return;
+      const outerW = outerRef.current.offsetWidth;
+      const innerW = innerRef.current.scrollWidth;
+      const innerH = innerRef.current.scrollHeight * 1.5;
+      const nextScale = innerW > outerW ? outerW / innerW : 1;
+      setScale(nextScale);
+      setScaledHeight(innerH * nextScale);
+      setIsScaled(nextScale < 1);
+    };
+
+    const raf = requestAnimationFrame(recalc);
+    const ro = new ResizeObserver(recalc);
+    if (outerRef.current) ro.observe(outerRef.current);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [data, teamData]);
 
   const inferCurrentSeriesFromPreviousRound = useCallback(
     (seriesToReturn: number, previousRound: PlayoffsSeries[]) => {
@@ -136,7 +166,6 @@ export const DoubleBracket = ({
           ? getSeriesByConference(data[i - 1], BracketConference.EASTERN)
           : [];
         const sortedRound = sortByDivision(previousRoundInfo);
-
         return inferCurrentSeriesFromPreviousRound(
           seriesPerRound[i],
           sortedRound,
@@ -169,61 +198,94 @@ export const DoubleBracket = ({
   return (
     <div
       className={classnames(
-        'mt-20 flex size-full flex-row content-between items-center pt-2.5',
+        'w-full',
+        isScaled ? 'overflow-hidden' : '',
         className,
       )}
+      style={isScaled ? { height: scaledHeight ?? 'auto' } : undefined}
     >
-      <div className="flex flex-wrap items-center">
-        {westernConferenceBracketData.map((round, i) => (
-          <div className="flex w-40 flex-col items-center" key={i}>
-            <h2 className="mb-2.5 text-2xl font-bold">
-              {round.length === 1 &&
-              round[0].team1.conference !== round[0].team2.conference
-                ? 'Finals'
-                : `Round ${i + 1}`}
-            </h2>
-            {round.map((series) => (
-              <PlayoffBracketSeries
-                key={`${series.team1.id}${series.team2.id}`}
-                series={series}
-                teamData={teamData}
-                league={league}
-                shouldUseTeamShortName
-              />
-            ))}
-          </div>
-        ))}
-      </div>
-      <div className="m-auto flex w-40 flex-col items-center">
-        <h2 className="mb-2.5 text-2xl font-bold">Finals</h2>
-        <PlayoffBracketSeries
-          key={`${finalsRoundDataIfExists.team1.id}${finalsRoundDataIfExists.team2.id}`}
-          series={finalsRoundDataIfExists}
-          teamData={teamData}
-          league={league}
-          shouldUseTeamShortName
-        />
-      </div>
-      <div className="flex flex-row-reverse flex-wrap items-center">
-        {easternConferenceBracketData.map((round, i) => (
-          <div className="flex w-40 flex-col items-center" key={i}>
-            <h2 className="mb-2.5 text-2xl font-bold">
-              {round.length === 1 &&
-              round[0].team1.conference !== round[0].team2.conference
-                ? 'Finals'
-                : `Round ${i + 1}`}
-            </h2>
-            {round.map((series) => (
-              <PlayoffBracketSeries
-                key={`${series.team1.id}${series.team2.id}`}
-                series={series}
-                teamData={teamData}
-                league={league}
-                shouldUseTeamShortName
-              />
-            ))}
-          </div>
-        ))}
+      <div
+        ref={innerRef}
+        className={classnames(
+          'mt-20 flex flex-row items-center pt-2.5',
+          !isScaled && 'size-full content-between',
+          isScaled && 'min-w-max',
+        )}
+        style={
+          isScaled
+            ? { transform: `scale(${scale})`, transformOrigin: 'top left' }
+            : undefined
+        }
+      >
+        <div
+          className={classnames(
+            'flex items-center',
+            !isScaled ? 'flex-wrap' : 'flex-row',
+          )}
+        >
+          {westernConferenceBracketData.map((round, i) => (
+            <div className="flex w-40 flex-col items-center" key={i}>
+              <h2 className="mb-2.5 text-2xl font-bold">
+                {round.length === 1 &&
+                round[0].team1.conference !== round[0].team2.conference
+                  ? 'Finals'
+                  : `Round ${i + 1}`}
+              </h2>
+              {round.map((series) => (
+                <PlayoffBracketSeries
+                  key={`${series.team1.id}${series.team2.id}`}
+                  series={series}
+                  teamData={teamData}
+                  league={league}
+                  shouldUseTeamShortName
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div
+          className={classnames(
+            'flex w-40 shrink-0 flex-col items-center',
+            !isScaled ? 'm-auto' : 'mx-2',
+          )}
+        >
+          <h2 className="mb-2.5 text-2xl font-bold">Finals</h2>
+          <PlayoffBracketSeries
+            key={`${finalsRoundDataIfExists.team1.id}${finalsRoundDataIfExists.team2.id}`}
+            series={finalsRoundDataIfExists}
+            teamData={teamData}
+            league={league}
+            shouldUseTeamShortName
+          />
+        </div>
+
+        <div
+          className={classnames(
+            'flex items-center',
+            !isScaled ? 'flex-row-reverse flex-wrap' : 'flex-row-reverse',
+          )}
+        >
+          {easternConferenceBracketData.map((round, i) => (
+            <div className="flex w-40 flex-col items-center" key={i}>
+              <h2 className="mb-2.5 text-2xl font-bold">
+                {round.length === 1 &&
+                round[0].team1.conference !== round[0].team2.conference
+                  ? 'Finals'
+                  : `Round ${i + 1}`}
+              </h2>
+              {round.map((series) => (
+                <PlayoffBracketSeries
+                  key={`${series.team1.id}${series.team2.id}`}
+                  series={series}
+                  teamData={teamData}
+                  league={league}
+                  shouldUseTeamShortName
+                />
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/components/playoffBracket/DoubleBracket.tsx
+++ b/components/playoffBracket/DoubleBracket.tsx
@@ -197,6 +197,7 @@ export const DoubleBracket = ({
 
   return (
     <div
+      ref={outerRef}
       className={classnames(
         'w-full',
         isScaled ? 'overflow-hidden' : '',

--- a/components/tables/LastFifteen.tsx
+++ b/components/tables/LastFifteen.tsx
@@ -74,7 +74,7 @@ export const LastFifteenTable = ({
                   {cellValue[0]}
                 </span>
                 <span className="mx-2.5 my-0 hidden min-w-max text-left text-blue600 md:inline">
-                  {cellValue[1]}
+                  {cellValue[1]} {cellValue[2]}
                 </span>
               </Link>
             );

--- a/pages/[league]/index.tsx
+++ b/pages/[league]/index.tsx
@@ -64,7 +64,7 @@ export default ({ league }: { league: League }) => {
                     Teams performance over the last 15 games
                   </span>
                 </div>
-                <TabList className="mt-2  sm:mt-0">
+                <TabList className="mt-2 sm:mt-0">
                   <Tab fontSize="sm">By Conference</Tab>
                   <Tab fontSize="sm">All Teams</Tab>
                 </TabList>

--- a/pages/[league]/index.tsx
+++ b/pages/[league]/index.tsx
@@ -64,7 +64,7 @@ export default ({ league }: { league: League }) => {
                     Teams performance over the last 15 games
                   </span>
                 </div>
-                <TabList className="mt-2 sm:mt-0">
+                <TabList className="mt-2  sm:mt-0">
                   <Tab fontSize="sm">By Conference</Tab>
                   <Tab fontSize="sm">All Teams</Tab>
                 </TabList>

--- a/pages/[league]/schedule.tsx
+++ b/pages/[league]/schedule.tsx
@@ -160,7 +160,7 @@ export default ({ league }: { league: League }) => {
                         <button
                           onClick={() => setRouterPageState('viewMode', mode)}
                           disabled={mode === 'table' && selectedTeam === -1}
-                          className={`px-3 py-1 capitalize transition-colors ${
+                          className={`px-4 py-2 text-base capitalize transition-colors sm:px-3 sm:py-1 sm:text-sm ${
                             viewMode === mode
                               ? 'bg-blue600'
                               : 'bg-primary text-secondary hover:bg-secondary'

--- a/pages/[league]/standings.tsx
+++ b/pages/[league]/standings.tsx
@@ -38,8 +38,8 @@ export default ({ league }: { league: League }) => {
         type === 'Playoffs'
           ? 'standings/playoffs'
           : type === 'Pre-Season'
-          ? 'standings/preseason'
-          : 'standings';
+            ? 'standings/preseason'
+            : 'standings';
       const displayParam =
         type !== 'Playoffs' ? `&display=${tabs[currentActiveTab]}` : '';
       const seasonParam = season ? `&season=${season}` : '';
@@ -79,17 +79,18 @@ export default ({ league }: { league: League }) => {
                 <DoubleBracket
                   data={data as Exclude<Standings | PlayoffsRound[], Standings>}
                   league={league}
-                  className="hidden xl:flex"
                 />
               )}
 
-              <SingleBracket
-                data={data as Exclude<Standings | PlayoffsRound[], Standings>}
-                league={league}
-                className={classnames(
-                  shouldShowDoublePlayoffsBracket && 'xl:hidden',
-                )}
-              />
+              {!shouldShowDoublePlayoffsBracket && (
+                <SingleBracket
+                  data={data as Exclude<Standings | PlayoffsRound[], Standings>}
+                  league={league}
+                  className={classnames(
+                    shouldShowDoublePlayoffsBracket && 'xl:hidden',
+                  )}
+                />
+              )}
             </>
           ) : (
             <>

--- a/pages/[league]/team/[teamid].tsx
+++ b/pages/[league]/team/[teamid].tsx
@@ -120,7 +120,7 @@ export default ({
     return {
       primary: bgColor,
       secondary: colors.secondary,
-      text: isDark ? '#F5F5F5' : colors.text,
+      text: isDark ? '#ffffff' : colors.text,
     };
   }, [colors]);
 

--- a/pages/[league]/team/[teamid].tsx
+++ b/pages/[league]/team/[teamid].tsx
@@ -1,4 +1,6 @@
+import { ExternalLinkIcon } from '@chakra-ui/icons';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '@chakra-ui/react';
+import { Link } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import classnames from 'classnames';
 import { partition } from 'lodash';
@@ -110,6 +112,17 @@ export default ({
     () => colors && tinycolor(colors.primary).isDark(),
     [colors],
   );
+  const displayColors = useMemo(() => {
+    const bgColor = tinycolor(colors.primary).isLight()
+      ? colors.secondary
+      : colors.primary;
+    const isDark = tinycolor(bgColor).isDark();
+    return {
+      primary: bgColor,
+      secondary: colors.secondary,
+      text: isDark ? '#F5F5F5' : colors.text,
+    };
+  }, [colors]);
 
   const [rosterSkaters, rosterGoalies] = useMemo(
     () =>
@@ -184,6 +197,16 @@ export default ({
             | <span className="mx-4">{stats.points} PTS</span> |{' '}
             <span className="ml-4">{stats.winPercent.toFixed(3)}</span>
           </h3>
+          <Link
+            href={`https://portal.simulationhockey.com/teams/${league}/${teamdata.id}`}
+            className={classnames(
+              teamColorIsDark ? '!text-grey100' : '!text-grey900',
+              'mt-2 font-mont text-sm',
+            )}
+            isExternal
+          >
+            View on Portal <ExternalLinkIcon mx="2px" />
+          </Link>
         </div>
       </div>
       <div className="m-auto w-full bg-primary p-[2.5%] lg:w-3/4 lg:p-8">
@@ -333,7 +356,11 @@ export default ({
             </TabPanel>
             {shouldShowLinesTab && (
               <TabPanel px={0}>
-                <Lines league={league} lines={teamLines} />
+                <Lines
+                  league={league}
+                  lines={teamLines}
+                  teamColors={displayColors}
+                />
               </TabPanel>
             )}
           </TabPanels>

--- a/utils/playerHelpers.ts
+++ b/utils/playerHelpers.ts
@@ -54,8 +54,19 @@ export const getPlayerShortname = (name: string): string => {
   return `${shortName}${splitName.slice(-1)}`;
 };
 
+export type AnyLine = {
+  LW?: { id: number; name: string };
+  C?: { id: number; name: string };
+  RW?: { id: number; name: string };
+  LD?: { id: number; name: string };
+  RD?: { id: number; name: string };
+};
+
+export const FORWARD_POSITIONS = ['LW', 'C', 'RW'] as const;
+export const DEFENSE_POSITIONS = ['LD', 'RD'] as const;
+
 export const calculateTimeOnIce = (toi: number, gamesPlayed: number) =>
-  `${(toi / gamesPlayed / 60) >> 0}:${((toi / gamesPlayed) % 60 >> 0)
+  `${(toi / gamesPlayed / 60) >> 0}:${(((toi / gamesPlayed) % 60) >> 0)
     .toString()
     .padStart(2, '0')}`;
 


### PR DESCRIPTION
New Line layout similar to puckpedia
New link on team pages to send the user to the portal page of the team 
Added the abbreviation CZE so the czechia logo appears on the WJC index 
Added full team name to the last fifteen table for IIHF and WJC
On mobile for double brackets, scale down the playoff bracket so that people get a better understanding of the playoff backet on mobile