### PR TITLE
Putting cards on the index

### DIFF
--- a/components/CardPreview.tsx
+++ b/components/CardPreview.tsx
@@ -1,0 +1,105 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalBody,
+  ModalCloseButton,
+  ModalHeader,
+  useDisclosure,
+  Image,
+  Box,
+} from '@chakra-ui/react';
+import React, { useRef } from 'react';
+
+const THRESHOLD = 30;
+
+export const CardPreview = ({ src }: { src: string }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const shineRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!cardRef.current || !shineRef.current) return;
+
+    const rect = cardRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left - rect.width / 2;
+    const y = e.clientY - rect.top - rect.height / 2;
+
+    cardRef.current.style.transform = `perspective(900px)
+    rotateX(${(-y / THRESHOLD).toFixed(2)}deg)
+    rotateY(${(x / THRESHOLD).toFixed(2)}deg)
+    scale(1.05)
+    `;
+
+    shineRef.current.style.background = `
+  radial-gradient(
+    circle at ${e.clientX - rect.left}px ${e.clientY - rect.top}px,
+    rgba(255,255,255,0.28),
+    rgba(255,255,255,0.12) 20%,
+    transparent 60%
+  )
+`;
+  };
+
+  const resetTransform = () => {
+    if (!cardRef.current || !shineRef.current) return;
+
+    cardRef.current.style.transform =
+      'perspective(1000px) rotateX(0deg) rotateY(0deg) scale(1)';
+
+    shineRef.current.style.background = 'none';
+  };
+
+  return (
+    <>
+      <Image
+        src={src}
+        onClick={onOpen}
+        cursor="pointer"
+        className="h-auto w-full rounded-sm transition-transform hover:scale-105"
+      />
+
+      <Modal isOpen={isOpen} onClose={onClose} isCentered size="auto">
+        <ModalOverlay />
+
+        <ModalContent
+          borderRadius="md"
+          overflow="hidden"
+          width="fit-content"
+          maxW="90vw"
+        >
+          <ModalHeader className="border-b-4 border-b-blue700 text-lg font-bold">
+            Card Preview
+          </ModalHeader>
+          <ModalCloseButton />
+
+          <ModalBody className="flex items-center justify-center p-2 md:p-4">
+            <Box
+              ref={cardRef}
+              onMouseMove={handleMouseMove}
+              onMouseLeave={resetTransform}
+              className="relative transition-transform duration-200 ease-out"
+              style={{ transformStyle: 'preserve-3d' }}
+            >
+              <Image
+                src={src}
+                className="max-h-[75vh] w-auto rounded-md"
+                objectFit="contain"
+              />
+
+              <Box
+                ref={shineRef}
+                position="absolute"
+                top="0"
+                left="0"
+                w="100%"
+                h="100%"
+                pointerEvents="none"
+              />
+            </Box>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};

--- a/components/PlayerCards.tsx
+++ b/components/PlayerCards.tsx
@@ -1,0 +1,15 @@
+import { PlayerCard } from 'typings/portal-api';
+
+import { CardPreview } from './CardPreview';
+
+export const PlayerCards = ({ cards }: { cards: PlayerCard[] }) => (
+  <div className="flex flex-col items-start gap-3">
+    {cards.length > 0 && (
+      <div className="grid w-full grid-cols-2 gap-3 md:grid-cols-6">
+        {cards.map((card, i) => (
+          <CardPreview key={i} src={card.image_url} />
+        ))}
+      </div>
+    )}
+  </div>
+);

--- a/pages/[league]/player/[id].tsx
+++ b/pages/[league]/player/[id].tsx
@@ -268,8 +268,8 @@ export default ({ playerId, league }: { playerId: string; league: League }) => {
                       <SeasonTypeSelector className="!h-7 w-48" />
                     </div>
 
-                    <div className="flex items-center gap-2">
-                      <div className="font-mont text-2xl font-bold uppercase leading-tight md:text-3xl">
+                    <div className="flex flex-col items-center gap-2 md:flex-row">
+                      <div className="text-center font-mont text-2xl font-bold uppercase leading-tight md:text-3xl">
                         {playerNameInfo?.name ?? 'Player'}
                       </div>
 
@@ -281,7 +281,7 @@ export default ({ playerId, league }: { playerId: string; league: League }) => {
                           <TeamLogo
                             league={league}
                             teamAbbreviation={playerInfo[0]?.team}
-                            className="size-7 md:size-9"
+                            className="size-14 md:size-9"
                           />
                         </Link>
                       )}

--- a/pages/[league]/player/[id].tsx
+++ b/pages/[league]/player/[id].tsx
@@ -7,9 +7,11 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
+  Image,
 } from '@chakra-ui/react';
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
 import classnames from 'classnames';
+import { PlayerCards } from 'components/PlayerCards';
 import { GoalieBoxscoreTable } from 'components/tables/GoalieBoxscoreTable';
 import { PlayerAwards } from 'components/tables/PlayerAwardsTables';
 import { SkaterBoxscoreTable } from 'components/tables/SkaterBoxscoreTable';
@@ -17,10 +19,12 @@ import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
 import { useTheme } from 'next-themes';
+import { pathToCards } from 'pages/api/v1/players/cards';
 import { useEffect, useMemo, useRef } from 'react';
 import {
-  InternalIndexPlayerID,
+  IndexPortalInfo,
   InternalPlayerAchievement,
+  PlayerCard,
 } from 'typings/portal-api';
 
 import { Footer } from '../../../components/Footer';
@@ -65,11 +69,19 @@ const fetchPlayerAwards = (league: League, playerId: string) =>
     )}&fhmID=${playerId}`,
   );
 
-const fetchPortalID = (league: League, playerId: string) =>
+const fetchPortalInfo = (
+  league: League,
+  playerId: string,
+): Promise<IndexPortalInfo[]> =>
   portalQuery(
-    `api/v1/player/index-ids?leagueID=${leagueNameToId(
+    `api/v1/player/index-info?leagueID=${leagueNameToId(
       league,
     )}&indexID=${playerId}`,
+  );
+
+const fetchPlayerCards = (league: League, playerId: string) =>
+  query(
+    `api/v1/players/cards?league=${leagueNameToId(league)}&playerid=${playerId}`,
   );
 
 export default ({ playerId, league }: { playerId: string; league: League }) => {
@@ -127,25 +139,16 @@ export default ({ playerId, league }: { playerId: string; league: League }) => {
     queryFn: () => fetchPlayerAwards(league, playerId),
   });
 
-  const { data: playerPortalID } = useQuery<InternalIndexPlayerID[]>({
-    queryKey: ['playerPortalID', league, playerId],
-    queryFn: () => fetchPortalID(league, playerId),
+  const { data: playerPortalInfo } = useQuery({
+    queryKey: ['playerPortalInfo', league, playerId],
+    queryFn: () => fetchPortalInfo(league, playerId),
+    select: (data) => data[0],
   });
 
-  const filteredPortalID = useMemo(() => {
-    if (!playerPortalID || playerPortalID.length === 0) return [];
-
-    if (season) {
-      const current = Number(season);
-      return playerPortalID.filter((entry) => entry.startSeason <= current);
-    }
-
-    const latest = playerPortalID.reduce(
-      (best, entry) => (entry.startSeason > best.startSeason ? entry : best),
-      playerPortalID[0],
-    );
-    return [latest];
-  }, [playerPortalID, season]);
+  const { data: playerCards } = useQuery<PlayerCard[]>({
+    queryKey: ['playerCards', league, playerId],
+    queryFn: () => fetchPlayerCards(league, playerId),
+  });
 
   const { data: playerRatings } = useQuery<PlayerRatings[] | GoalieRatings[]>({
     queryKey: ['playerRatings', league, playerId, playerTypeInfo?.playerType],
@@ -232,51 +235,99 @@ export default ({ playerId, league }: { playerId: string; league: League }) => {
               shouldShowIndexView && 'lg:w-11/12',
             )}
           >
-            <div className="flex flex-col items-center md:mr-8 md:flex-row md:justify-end">
-              <SeasonTypeSelector
-                className={classnames('mb-4 md:mb-0 md:ml-4', {
-                  'top-7 !h-7 w-48': shouldShowIndexView,
-                })}
-              />
-            </div>
             {shouldShowIndexView && (
-              <div className="my-2.5 flex flex-col items-center justify-center space-y-5">
-                <Link
-                  href={`/${league}/team/${playerInfo[0].teamID}`}
-                  aria-label={`View ${playerInfo[0].team}'s page`}
-                >
-                  <TeamLogo
-                    league={league}
-                    teamAbbreviation={playerInfo[0]?.team}
-                    className="mt-10 size-40 md:mt-2.5"
-                  />
-                </Link>
-                <div className=" group flex items-center gap-2 text-3xl font-bold uppercase">
-                  {playerNameInfo?.name ?? 'Player'}
-                </div>
-                <div>
-                  {shouldShowIndexView && filteredPortalID.length > 0 && (
-                    <div className="space-y-1 text-center">
-                      {filteredPortalID.map((entry) => (
+              <div className="my-4 px-4">
+                <div className="flex flex-col items-center gap-4 md:flex-row md:items-center md:gap-6">
+                  <div className="order-2 flex shrink-0 items-center justify-center md:order-1">
+                    {playerCards && playerCards.length > 0 ? (
+                      <Image
+                        src={
+                          playerPortalInfo?.selectedImage
+                            ? `${pathToCards}${playerPortalInfo.selectedImage}`
+                            : playerCards[0].image_url
+                        }
+                        alt={`${playerNameInfo?.name ?? 'Player'} card`}
+                        className="h-44 w-auto rounded-md object-contain md:h-48"
+                      />
+                    ) : (
+                      <Link
+                        href={`/${league}/team/${playerInfo[0].teamID}`}
+                        aria-label={`View ${playerInfo[0].team}'s page`}
+                      >
+                        <TeamLogo
+                          league={league}
+                          teamAbbreviation={playerInfo[0]?.team}
+                          className="size-32 md:size-40"
+                        />
+                      </Link>
+                    )}
+                  </div>
+
+                  <div className="order-1 flex min-w-0 flex-1 flex-col items-center gap-2 md:order-2 md:items-start">
+                    <div className="flex w-full justify-center md:justify-end">
+                      <SeasonTypeSelector className="!h-7 w-48" />
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <div className="font-mont text-2xl font-bold uppercase leading-tight md:text-3xl">
+                        {playerNameInfo?.name ?? 'Player'}
+                      </div>
+
+                      {playerCards && playerCards.length > 0 && (
                         <Link
-                          key={entry.playerUpdateID}
+                          href={`/${league}/team/${playerInfo[0].teamID}`}
+                          className="flex-shrink-0"
+                        >
+                          <TeamLogo
+                            league={league}
+                            teamAbbreviation={playerInfo[0]?.team}
+                            className="size-7 md:size-9"
+                          />
+                        </Link>
+                      )}
+                    </div>
+
+                    {playerPortalInfo && (
+                      <div className="text-center font-mont text-sm text-secondary md:text-left">
+                        <Link
                           className="!text-blue600"
-                          href={`https://portal.simulationhockey.com/player/${entry.playerUpdateID}`}
+                          href={`https://simulationhockey.com/member.php?action=profile&uid=${playerPortalInfo.userID}`}
+                          isExternal
+                        >
+                          {playerPortalInfo.username}
+                        </Link>
+                        {' · '}#{playerPortalInfo.jerseyNumber}
+                        {' · '}S{playerPortalInfo.season}
+                        {' · '}
+                        <Link
+                          className="!text-blue600"
+                          href={`https://portal.simulationhockey.com/player/${playerPortalInfo.playerUpdateID}`}
                           isExternal
                         >
                           View in portal <ExternalLinkIcon mx="2px" />
                         </Link>
-                      ))}
+                      </div>
+                    )}
+
+                    <div className="text-center font-mont text-lg uppercase">
+                      {'position' in playerInfo[0]
+                        ? playerInfo[0].position
+                        : 'G'}{' '}
+                      | {Math.floor(playerInfo[0].height / 12)} ft{' '}
+                      {playerInfo[0].height % 12} in | {playerInfo[0].weight}{' '}
+                      lbs
                     </div>
-                  )}
-                </div>
-                <div className="text-center font-mont text-lg uppercase">
-                  {'position' in playerInfo[0] ? playerInfo[0].position : 'G'} |{' '}
-                  {Math.floor(playerInfo[0].height / 12)} ft{' '}
-                  {playerInfo[0].height % 12} in | {playerInfo[0].weight} lbs
+                  </div>
                 </div>
               </div>
             )}
+
+            {!shouldShowIndexView && (
+              <div className="flex flex-col items-center md:mr-8 md:flex-row md:justify-end">
+                <SeasonTypeSelector className="top-7 mb-4 !h-7 w-48 md:mb-0 md:ml-4" />
+              </div>
+            )}
+
             <Tabs isLazy>
               <TabList flexWrap="wrap">
                 <Tab
@@ -313,16 +364,22 @@ export default ({ playerId, league }: { playerId: string; league: League }) => {
                 >
                   Game Logs
                 </Tab>
-                {playerAwards && playerAwards.length > 0 && (
-                  <Tab
-                    _selected={{
-                      color: 'rgb(var(--hyperlink))',
-                      borderBottomColor: 'rgb(var(--hyperlink))',
-                    }}
-                  >
-                    Awards
-                  </Tab>
-                )}
+                <Tab
+                  _selected={{
+                    color: 'rgb(var(--hyperlink))',
+                    borderBottomColor: 'rgb(var(--hyperlink))',
+                  }}
+                >
+                  Awards
+                </Tab>
+                <Tab
+                  _selected={{
+                    color: 'rgb(var(--hyperlink))',
+                    borderBottomColor: 'rgb(var(--hyperlink))',
+                  }}
+                >
+                  Cards
+                </Tab>
               </TabList>
               <TabPanels>
                 <TabPanel>
@@ -409,6 +466,9 @@ export default ({ playerId, league }: { playerId: string; league: League }) => {
                   {playerAwards && playerAwards.length > 0 && (
                     <PlayerAwards playerAwards={playerAwards} />
                   )}
+                </TabPanel>
+                <TabPanel>
+                  {playerCards && <PlayerCards cards={playerCards} />}
                 </TabPanel>
               </TabPanels>
             </Tabs>

--- a/pages/api/v1/players/cards.ts
+++ b/pages/api/v1/players/cards.ts
@@ -1,0 +1,50 @@
+//@ts-nocheck
+import Cors from 'cors';
+import { NextApiRequest, NextApiResponse } from 'next';
+import SQL from 'sql-template-strings';
+
+import { query } from '../../../../lib/db';
+import use from '../../../../lib/middleware';
+
+const cors = Cors({
+  methods: ['GET', 'HEAD'],
+});
+
+export const pathToCards = 'https://simulationhockey.com/tradingcards/';
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  await use(req, res, cors);
+
+  const { league, playerid } = req.query;
+
+  if (!league || !playerid) {
+    res.status(400).end('Missing league or playerid');
+    return;
+  }
+
+  const cards = await query(SQL`
+    SELECT playerID, leagueID, overall, image_url
+    FROM cards
+    WHERE playerID=${+playerid}
+    AND leagueID=${+league}
+    ORDER BY overall DESC
+  `);
+
+  if ('error' in cards) {
+    res.status(500).end('Server connection failed');
+    return;
+  }
+
+  const parsed = cards.map((card) => ({
+    playerID: card.playerID,
+    leagueID: card.leagueID,
+    card_rarity: card.card_rarity,
+    overall: card.overall,
+    image_url: `${pathToCards}${card.image_url}`,
+  }));
+
+  res.status(200).json(parsed);
+};

--- a/typings/portal-api.d.ts
+++ b/typings/portal-api.d.ts
@@ -13,9 +13,23 @@ export type InternalPlayerAchievement = {
   won: boolean;
 };
 
-export type InternalIndexPlayerID = {
+export type IndexPortalInfo = {
   playerUpdateID: number;
   leagueID: number;
   indexID: number;
   startSeason: number;
+  username: string;
+  userID: number;
+  handedness: string;
+  season: number;
+  jerseyNumber: number;
+  selectedImage: string;
+};
+
+type PlayerCard = {
+  indexID: number;
+  leagueID: number;
+  card_rarity: string;
+  overall: number;
+  image_url: string;
 };


### PR DESCRIPTION
New Layout for player page to accommodate for Portal Information and Card information

For Awards and Cards tabs, I kept them visible for everyone even though people with no awards will see the tabs. Just because people may or may not have awards or cards but I want them to view either or. Having tabs hidden fucked with it. So just opted to keep them both visible

On the top area, changed the format of where things are. If they have the portalID linked in through indexID then it shows the jersey number, season, and username.  Then if they choose a card, it will view the specific card

If they have a card associated with the player it will populate the cards. If the user didnt select a specific card in the portal it will just be the highest OVR


<img width="1442" height="775" alt="image" src="https://github.com/user-attachments/assets/a0c46228-2fb8-455e-84e5-f54b570ce69c" />
<img width="1216" height="606" alt="image" src="https://github.com/user-attachments/assets/527978b3-4389-489a-9591-cc1fa6cb122b" />
<img width="1573" height="673" alt="image" src="https://github.com/user-attachments/assets/aef0f062-5583-4941-bad0-4c7557651ca7" />
<img width="1442" height="537" alt="image" src="https://github.com/user-attachments/assets/1212d74d-c1dd-40da-85b2-9937424411cc" />
<img width="1448" height="691" alt="image" src="https://github.com/user-attachments/assets/deb0a7d9-4c13-4bba-a31a-9fe87be6a412" />
<img width="1480" height="742" alt="image" src="https://github.com/user-attachments/assets/ccac80dc-1a44-47a8-93eb-bdaacc3f570a" />
<img width="512" height="742" alt="image" src="https://github.com/user-attachments/assets/0193dafd-4342-46e2-afa5-264666bdc222" />
